### PR TITLE
corrected templateDeclaration closing tag

### DIFF
--- a/astprinter.d
+++ b/astprinter.d
@@ -1175,7 +1175,7 @@ class XMLPrinter : ASTVisitor
 		{
 			if (dec !is null) visit(dec);
 		}
-		output.writeln("<templateDeclaration>");
+		output.writeln("</templateDeclaration>");
 	}
 
 	override void visit(TemplateInstance templateInstance)


### PR DESCRIPTION
Previously an opening tag <templateDeclaration> was written instead of a closing tag </templateDeclaration>
