### PR TITLE
Fix --ast crash on empty 'for' init decl/statement

### DIFF
--- a/astprinter.d
+++ b/astprinter.d
@@ -464,9 +464,12 @@ class XMLPrinter : ASTVisitor
 	override void visit(ForStatement forStatement)
 	{
 		output.writeln("<forStatement>");
-		output.writeln("<initialize>");
-		visit(forStatement.declarationOrStatement);
-		output.writeln("</initialize>");
+		if (forStatement.declarationOrStatement !is null)
+		{
+			output.writeln("<initialize>");
+			visit(forStatement.declarationOrStatement);
+			output.writeln("</initialize>");
+		}
 		if (forStatement.test !is null)
 		{
 			output.writeln("<test>");


### PR DESCRIPTION
Tried to run dscanner against std.algorithm and it crashed on an empty `for` initializer (`for (; r.empty; r.popFront)`).
