### PR TITLE
Fix: unary expression unexpected end, range violations

### DIFF
--- a/stdx/d/parser.d
+++ b/stdx/d/parser.d
@@ -3523,6 +3523,8 @@ invariant() foo();
         else
         {
             expect(tok!"new");
+            if (!moreTokens())
+                return null;
             node.type = parseType();
             if (currentIs(tok!"["))
             {
@@ -5651,6 +5653,8 @@ q{(int a, ...)
     UnaryExpression parseUnaryExpression()
     {
         mixin(traceEnterAndExit!(__FUNCTION__));
+        if (!moreTokens())
+            return null;
         auto node = new UnaryExpression;
         switch (current.type)
         {


### PR DESCRIPTION
This fixes some unary expressions which end unexpectedly, i.e.:

```
void main() { + EOF
void main() { new EOF
void main() { delete EOF
```

Not sure how you want to deal with the range violations, but the pull at least shows the problem.
