### PR TITLE
publish Parser.moreToken method

### DIFF
--- a/stdx/d/parser.d
+++ b/stdx/d/parser.d
@@ -6522,7 +6522,7 @@ protected:
     /**
      * Returns: true if there are more tokens
      */
-    bool moreTokens() const nothrow
+    public bool moreTokens() const nothrow
     {
         return index < tokens.length;
     }


### PR DESCRIPTION
- Otherwise it's not possible to know whether a parse
  consumed the whole input.
