### PR TITLE
debug/version = blah is treated as a statement

### DIFF
--- a/stdx/d/parser.d
+++ b/stdx/d/parser.d
@@ -6097,7 +6097,7 @@ protected:
             return !peekIs(tok!"switch");
         case tok!"debug":
         case tok!"version":
-            return peekIs(tok!"=");
+            return !peekIs(tok!"=");
         case tok!"synchronized":
             if (peekIs(tok!"("))
                 return false;


### PR DESCRIPTION
The parser treats `debug = foo;` as a statement, but isDeclaration was returning true for this pattern.
