### PR TITLE
Allow function attributes in lambda expression

### DIFF
--- a/stdx/d/parser.d
+++ b/stdx/d/parser.d
@@ -4149,6 +4149,8 @@ q{(int a, ...)
                 auto b = setBookmark();
                 advance(); // function | delegate
                 skipParens();
+                while (isAttribute())
+                    parseAttribute();
                 if (currentIs(tok!"=>"))
                 {
                     goToBookmark(b);


### PR DESCRIPTION
Without this:

```
function(int a)nothrow=>1;
```

is rejected.
