### PR TITLE
Allow typeof expression in template mixin

### DIFF
--- a/stdx/d/parser.d
+++ b/stdx/d/parser.d
@@ -3384,7 +3384,7 @@ invariant() foo();
     {
         mixin(traceEnterAndExit!(__FUNCTION__));
         auto node = new MixinDeclaration;
-        if (peekIs(tok!"identifier"))
+        if (peekIs(tok!"identifier") || peekIs(tok!"typeof"))
             node.templateMixinExpression = parseTemplateMixinExpression();
         else if (peekIs(tok!"("))
             node.mixinExpression = parseMixinExpression();


### PR DESCRIPTION
Since mixinTemplateName can start be a `typeof(thing).thing`, check for this.

Aside: I only just checked to make sure that the unittests for the parser still succeed (they do). Is there anything else you run to test changes here?
