### PR TITLE
Check for constructor args in new anon class expression

### DIFF
--- a/stdx/d/parser.d
+++ b/stdx/d/parser.d
@@ -3527,6 +3527,8 @@ invariant() foo();
         if (currentIs(tok!"("))
             node.allocatorArguments = parseArguments();
         expect(tok!"class");
+        if (currentIs(tok!"("))
+            node.constructorArguments = parseArguments();
         if (!currentIs(tok!"{"))
             node.baseClassList = parseBaseClassList();
         node.structBody = parseStructBody();


### PR DESCRIPTION
Anonymous class can have constructor args:

```
auto a = new class(1) A { this(int a){} int _a; };
```
