### PR TITLE
Distinguish between conditional dec and stmnt

### DIFF
--- a/stdx/d/parser.d
+++ b/stdx/d/parser.d
@@ -6105,7 +6105,15 @@ protected:
             return !peekIs(tok!"switch");
         case tok!"debug":
         case tok!"version":
-            return !peekIs(tok!"=");
+        {
+            if (peekIs(tok!"="))
+                return false;
+
+            auto b = setBookmark();
+            scope (exit) goToBookmark(b);
+            advance();
+            return isDeclaration();
+        }
         case tok!"synchronized":
             if (peekIs(tok!"("))
                 return false;


### PR DESCRIPTION
Without this, the following fails:

```
debug(blah) writeln();
```

Because parser is treating it as a ConditionalDeclaration instead of a ConditionalStatement. I only picked this up when trying to format std.algorithm.
