### PR TITLE
Fix for struct init vs func literal, and this(a, b); being treated as a constructor declaration

### DIFF
--- a/stdx/d/parser.d
+++ b/stdx/d/parser.d
@@ -6186,6 +6186,14 @@ protected:
         case tok!"{":
         case tok!"assert":
             return false;
+        case tok!"this":
+            auto b = setBookmark();
+            scope (exit) goToBookmark(b);
+            advance();
+            auto p = peekPastParens();
+            if (p !is null && p.type == tok!";")
+                return false;
+            break;
         default:
             break;
         }


### PR DESCRIPTION
Distinguish between these:

```
auto a = { return 1; }(); // func literal call
auto b = {1, 2, 3}; // structure init
```

And treat:

```
this(blah);
```

as a function call, not constructor decl.
