### PR TITLE
Fixes for nonVoidInit and isDeclaration

### DIFF
--- a/stdx/d/parser.d
+++ b/stdx/d/parser.d
@@ -6188,9 +6188,9 @@ protected:
             return false;
         case tok!"this":
             auto b = setBookmark();
-            scope (exit) goToBookmark(b);
             advance();
             auto p = peekPastParens();
+            goToBookmark(b);
             if (p !is null && p.type == tok!";")
                 return false;
             break;


### PR DESCRIPTION
Distinguish between:

```
auto a = { return 1; }(); 
and
auto b = {1, 2, 3};
```

And fixes bug where:

```
this(a,b);
```

was treated as a constructor declaration.
