### PR TITLE
Distinguish between struct initializer and func literal call expression

### DIFF
--- a/stdx/d/parser.d
+++ b/stdx/d/parser.d
@@ -3875,7 +3875,13 @@ invariant() foo();
         mixin(traceEnterAndExit!(__FUNCTION__));
         auto node = allocate!NonVoidInitializer;
         if (currentIs(tok!"{"))
-            node.structInitializer = parseStructInitializer();
+        {
+            auto b = peekPastBraces();
+            if (b !is null && (b.type == tok!"("))
+                node.assignExpression = parseAssignExpression();
+            else
+                node.structInitializer = parseStructInitializer();
+        }
         else if (currentIs(tok!"["))
         {
             auto b = peekPastBrackets();


### PR DESCRIPTION
This distinguishes between:

```
S s = {1, 2, 3}; // struct init
S s = { return S(1,2,3); }(); // assign expr
```
