### PR TITLE
Attribute declarations can have attributes

### DIFF
--- a/stdx/d/parser.d
+++ b/stdx/d/parser.d
@@ -1731,6 +1731,7 @@ class ClassFour(A, B) if (someTest()) : Super {}}c;
             if (currentIs(tok!":"))
             {
                 node.attributeDeclaration = parseAttributeDeclaration(attr);
+                node.attributes = ownArray(attributes);
                 return node;
             }
             else


### PR DESCRIPTION
```
@safe pure nothrow: 
int x;
```

The `nothrow` attribute decl itself has attributes.
