### PR TITLE
Added missing check for <>=, the deprecated floating point operator.

### DIFF
--- a/analysis/fish.d
+++ b/analysis/fish.d
@@ -24,6 +24,7 @@ class FloatOperatorCheck : BaseAnalyzer
 	override void visit(const RelExpression r)
 	{
 		if (r.operator == tok!"<>"
+			|| r.operator == tok!"<>="
 			|| r.operator == tok!"!<>"
 			|| r.operator == tok!"!>"
 			|| r.operator == tok!"!<"


### PR DESCRIPTION
The check for the deprecated <>= was missing in the floating point checker.

[Floating point NCEG operators](http://dlang.org/deprecate.html#Floating point NCEG operators)
