### PR TITLE
Removed the hard coded -m64 in the build.sh script.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ dmd\
 	std/d/*.d\
 	analysis/*.d\
 	-ofdscanner\
-	-m64 -g\
+	-g\
 	-O -release
 
 #gdc\


### PR DESCRIPTION
Is there any reason why we would need the hard coded -m64? I've been building on 32bit Ubuntu & Fedora, and it is annoying to have to remove, and re add it.
