### PR TITLE
Some more location information and added declaration attributes into FunctionDeclaration scope

### DIFF
--- a/std/d/ast.d
+++ b/std/d/ast.d
@@ -1531,6 +1531,7 @@ public:
     /** */ FunctionBody functionBody;
     /** */ MemberFunctionAttribute[] memberFunctionAttributes;
     /** */ string comment;
+    /** */ Attribute[] attributes;
     mixin OpEquals;
 }
 

--- a/std/d/parser.d
+++ b/std/d/parser.d
@@ -1790,7 +1790,7 @@ class ClassFive(A, B) : Super if (someTest()) {}}c;
                 if (peekIs(tok!"="))
                     node.variableDeclaration = parseVariableDeclaration(null, true);
                 else if (peekIs(tok!"("))
-                    node.functionDeclaration = parseFunctionDeclaration(null, true);
+                    node.functionDeclaration = parseFunctionDeclaration(null, true, node.attributes);
                 else
                     goto type;
             }
@@ -1811,7 +1811,7 @@ class ClassFive(A, B) : Super if (someTest()) {}}c;
                 return null;
             }
             if (peekIs(tok!"("))
-                node.functionDeclaration = parseFunctionDeclaration(type);
+                node.functionDeclaration = parseFunctionDeclaration(type, false, node.attributes);
             else
                 node.variableDeclaration = parseVariableDeclaration(type);
             break;
@@ -2540,13 +2540,15 @@ body {} // six
      *       ($(RULE storageClass) | $(RULE _type)) $(LITERAL Identifier) $(RULE templateParameters) $(RULE parameters) $(RULE memberFunctionAttribute)* $(RULE constraint)? ($(RULE functionBody) | $(LITERAL ';'))
      *     ;)
      */
-    FunctionDeclaration parseFunctionDeclaration(Type type = null, bool isAuto = false)
+    FunctionDeclaration parseFunctionDeclaration(Type type = null, bool isAuto = false, Attribute[] attributes = null)
     {
         mixin(traceEnterAndExit!(__FUNCTION__));
         auto node = allocate!FunctionDeclaration;
         node.comment = comment;
         comment = null;
         MemberFunctionAttribute[] memberFunctionAttributes;
+
+        node.attributes = attributes;
 
         if (isAuto)
             goto functionName;


### PR DESCRIPTION
Hi,

I pushed the node.attributes to the FunctionDeclaration as there is no back pointer to the container of the node, and I need to know what are the attributes of the function when I 'visit' a FunctionDeclaration object.
Also, I did not want to "mess" with the memberFunctionAttributes member, so I added another member.

Rest is some more location information that I need while visiting some other nodes.

Thanks
Liran
