### PR TITLE
added enum constants to --ctags output

### DIFF
--- a/ctags.d
+++ b/ctags.d
@@ -156,6 +156,16 @@ class CTagsPrinter : ASTVisitor
 		dec.accept(this);
 	}
 
+	override void visit(const AutoDeclaration dec)
+	{
+		foreach (i; dec.identifiers)
+		{
+			tagLines ~= "%s\t%s\t%d;\"\tv%s\n".format(i.text, fileName,
+				i.line, context);
+		}
+		dec.accept(this);
+	}
+
 	override void visit(const Invariant dec)
 	{
 		tagLines ~= "invariant\t%s\t%d;\"\tv%s\n".format(fileName, dec.line, context);


### PR DESCRIPTION
Hey,

--ctags output was missing autodeclarations in the form of

```
enum foo = 0;
```

Is this fix correct?
