### PR TITLE
Fix crash with empty file

### DIFF
--- a/analysis/run.d
+++ b/analysis/run.d
@@ -62,6 +62,7 @@ void analyze(File output, string[] fileNames, AnalyzerCheck analyzers, bool stat
 	foreach (fileName; fileNames)
 	{
 		File f = File(fileName);
+		if (f.size == 0) continue;
 		auto code = uninitializedArray!(ubyte[])(to!size_t(f.size));
 		f.rawRead(code);
 

--- a/ctags.d
+++ b/ctags.d
@@ -24,6 +24,7 @@ void printCtags(File output, string[] fileNames)
 	foreach (fileName; fileNames)
 	{
 		File f = File(fileName);
+		if (f.size == 0) continue;
 		auto bytes = uninitializedArray!(ubyte[])(to!size_t(f.size));
 		f.rawRead(bytes);
 		auto tokens = getTokensForParser(bytes, config, &cache);

--- a/main.d
+++ b/main.d
@@ -255,6 +255,7 @@ ubyte[] readFile(string fileName)
 		return [];
 	}
 	File f = File(fileName);
+	if (f.size == 0) return [];
 	ubyte[] sourceCode = uninitializedArray!(ubyte[])(to!size_t(f.size));
 	f.rawRead(sourceCode);
 	return sourceCode;


### PR DESCRIPTION
`uninitializedArray!T(0)` returns null, so Dscanner failed in File.rawRead if an input file is empty.
