### PR TITLE
Fix prefix/suffix of unaryExpression in AST xml

### DIFF
--- a/astprinter.d
+++ b/astprinter.d
@@ -1422,14 +1422,15 @@ class XMLPrinter : ASTVisitor
 		output.writeln("<unaryExpression>");
 		if (unaryExpression.prefix != tok!"")
 		{
-			output.writeln("<prefix>", xmlEscape(unaryExpression.prefix.text),
+			output.writeln("<prefix>", xmlEscape(str(unaryExpression.prefix.type)),
 				"</prefix>");
 			unaryExpression.unaryExpression.accept(this);
 		}
 		if (unaryExpression.suffix != tok!"")
 		{
+			assert(unaryExpression.suffix.text == "");
 			unaryExpression.unaryExpression.accept(this);
-			output.writeln("<suffix>", unaryExpression.suffix.text,
+			output.writeln("<suffix>", str(unaryExpression.suffix.type),
 				"</suffix>");
 		}
 		else


### PR DESCRIPTION
prefix and suffx of unaryExpressions seem to be always empty in AST xml.

For example, I got this for code `*i`:

``` xml
<unaryExpression>
    <prefix></prefix> <!-- empty? -->
    <primaryExpression>
        <identifierOrTemplateInstance>
            <identifier>i</identifier>
        </identifierOrTemplateInstance>
    </primaryExpression>
    <unaryExpression>
        <primaryExpression>
            <identifierOrTemplateInstance>
                <identifier>i</identifier>
            </identifierOrTemplateInstance>
        </primaryExpression>
    </unaryExpression>
</unaryExpression>
```
