### PR TITLE
fix #431, Virtual call in ctor - problem with overloaded virtual methods

### DIFF
--- a/src/analysis/config.d
+++ b/src/analysis/config.d
@@ -172,8 +172,8 @@ struct StaticAnalysisConfig
 	string properly_documented_public_functions = Check.disabled;
 
     @INI("Check for useless usage of the final attribute")
-    string final_attribute_check = Check.disabled;
+    string final_attribute_check = Check.enabled;
 
     @INI("Check for virtual calls in the class constructors")
-    string vcall_in_ctor = Check.disabled;
+    string vcall_in_ctor = Check.enabled;
 }

--- a/src/analysis/vcall_in_ctor.d
+++ b/src/analysis/vcall_in_ctor.d
@@ -135,7 +135,10 @@ private:
             foreach (vm; _virtualMethods[$-1])
         {
             if (call == vm)
+            {
                 addErrorMessage(call.line, call.column, KEY, MSG);
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
Also enable the check, which was not by default.