### PR TITLE
Add installing with DUB instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ makefile has "ldc" and "gdc" targets if you'd prefer to compile with one of thes
 compilers instead of DMD. To install, simply place the generated binary (in the
 "bin" folder) somewhere on your $PATH.
 
+### Installing with DUB
+
+```sh
+> dub fetch dscanner && dub run dscanner
+```
+
 # Usage
 The following examples assume that we are analyzing a simple file called helloworld.d
 


### PR DESCRIPTION
DUB can be a controversial topic, but it definitely makes the installation for newcomers a lot easier. Hence, I don't see any reason why we shouldn't advertise this.

However, [as long as `dub fetch` doesn't support fetching alphas and betas](https://github.com/dlang/dub/issues/1126), releasing minor releases of critical bug fixes, might be a good ideas ;-)