### PR TITLE
Fix #422 - False negative: sorted imports with :

### DIFF
--- a/src/analysis/imports_sortedness.d
+++ b/src/analysis/imports_sortedness.d
@@ -72,7 +72,7 @@ class ImportSortednessCheck : BaseAnalyzer
 
 			foreach (importBind; id.importBindings.importBinds)
 			{
-				addImport(importModuleName ~ "_" ~ importBind.left.text, id.importBindings.singleImport);
+				addImport(importModuleName ~ "-" ~ importBind.left.text, id.importBindings.singleImport);
 			}
 		}
 	}
@@ -340,6 +340,12 @@ unittest
 		ImportSortednessCheck.MESSAGE,
 		ImportSortednessCheck.MESSAGE,
 	), sac);
+
+	// issue 422 - sorted imports with :
+	assertAnalyzerWarnings(q{
+		import foo.bar : bar;
+		import foo.barbar;
+	}, sac);
 
 	stderr.writeln("Unittest for ImportSortednessCheck passed.");
 }

--- a/src/analysis/imports_sortedness.d
+++ b/src/analysis/imports_sortedness.d
@@ -347,5 +347,14 @@ unittest
 		import foo.barbar;
 	}, sac);
 
+	// issue 422 - sorted imports with :
+	assertAnalyzerWarnings(q{
+		import foo;
+		import foo.bar;
+		import fooa;
+        import std.range : Take;
+        import std.range.primitives : isInputRange, walkLength;
+	}, sac);
+
 	stderr.writeln("Unittest for ImportSortednessCheck passed.");
 }


### PR DESCRIPTION
I already thought about this, but didn't realize that lexicographical order isn't equivalent to the ASCII table (and apparently no test covered this).

edit: sorry for the typo in the branch name