### PR TITLE
Fix more problems in the sorted import checker

### DIFF
--- a/src/analysis/imports_sortedness.d
+++ b/src/analysis/imports_sortedness.d
@@ -32,6 +32,11 @@ class ImportSortednessCheck : BaseAnalyzer
 	mixin ScopedVisit!TemplateDeclaration;
 	mixin ScopedVisit!ConditionalDeclaration;
 
+	override void visit(const VariableDeclaration id)
+	{
+		imports[level] = [];
+	}
+
 	override void visit(const ImportDeclaration id)
 	{
 		import std.algorithm.iteration : map;
@@ -364,6 +369,16 @@ unittest
 		{
 			import t1;
 		}
+	}
+	}, sac);
+
+	// intermediate imports
+	assertAnalyzerWarnings(q{
+	unittest
+	{
+		import t2;
+		int a = 1;
+		import t1;
 	}
 	}, sac);
 

--- a/src/analysis/imports_sortedness.d
+++ b/src/analysis/imports_sortedness.d
@@ -24,33 +24,13 @@ class ImportSortednessCheck : BaseAnalyzer
 		super(fileName, null, skipTests);
 	}
 
-	override void visit(const Module mod)
-	{
-		level = 0;
-		imports[level] = [];
-		mod.accept(this);
-	}
-
-	override void visit(const Statement decl)
-	{
-		imports[++level] = [];
-		decl.accept(this);
-		level--;
-	}
-
-	override void visit(const BlockStatement decl)
-	{
-		imports[++level] = [];
-		decl.accept(this);
-		level--;
-	}
-
-	override void visit(const StructBody decl)
-	{
-		imports[++level] = [];
-		decl.accept(this);
-		level--;
-	}
+	mixin ScopedVisit!Module;
+	mixin ScopedVisit!Statement;
+	mixin ScopedVisit!BlockStatement;
+	mixin ScopedVisit!StructBody;
+	mixin ScopedVisit!IfStatement;
+	mixin ScopedVisit!TemplateDeclaration;
+	mixin ScopedVisit!ConditionalDeclaration;
 
 	override void visit(const ImportDeclaration id)
 	{
@@ -83,6 +63,16 @@ private:
 
 	int level = 0;
 	string[][int] imports;
+
+	template ScopedVisit(NodeType)
+	{
+		override void visit(const NodeType n)
+		{
+			imports[++level] = [];
+			n.accept(this);
+			level--;
+		}
+	}
 
 	void addImport(string importModuleName, const SingleImport singleImport)
 	{
@@ -354,6 +344,27 @@ unittest
 		import fooa;
         import std.range : Take;
         import std.range.primitives : isInputRange, walkLength;
+	}, sac);
+
+	// condition declaration
+	assertAnalyzerWarnings(q{
+		import t2;
+		version(unittest)
+		{
+			import t1;
+		}
+	}, sac);
+
+	// if statements
+	assertAnalyzerWarnings(q{
+	unittest
+	{
+		import t2;
+		if (true)
+		{
+			import t1;
+		}
+	}
 	}, sac);
 
 	stderr.writeln("Unittest for ImportSortednessCheck passed.");


### PR DESCRIPTION
- ignore conditional declarations and if statements
- allow "unsorted" intermediate imports (i.e. after a couple of declarations) - this might be controversial