### PR TITLE
Allow duplicate braces in allman style

### DIFF
--- a/src/analysis/allman.d
+++ b/src/analysis/allman.d
@@ -40,12 +40,18 @@ class AllManCheck : BaseAnalyzer
 				// ignore struct initialization
 				if (tokens[i-1].type == tok!"=")
 					continue;
+				// ignore duplicate braces
+				if (tokens[i-1].type == tok!"{" && tokens[i - 2].line != curLine)
+					continue;
 				// ignore inline { } braces
 				if (curLine != tokens[i + 1].line)
 					addErrorMessage(tokens[i].line, tokens[i].column, KEY, MESSAGE);
 			}
 			if (tokens[i].type == tok!"}" && curLine == prevTokenLine)
 			{
+				// ignore duplicate braces
+				if (tokens[i-1].type == tok!"}" && tokens[i - 2].line != curLine)
+					continue;
 				// ignore inline { } braces
 				if (!tokens[0 .. i].retro.until!(t => t.line != curLine).canFind!(t => t.type == tok!"{"))
 					addErrorMessage(tokens[i].line, tokens[i].column, KEY, MESSAGE);
@@ -128,6 +134,14 @@ unittest
 	};
 }
 	}, sac);
+
+	// allow duplicate braces
+	assertAnalyzerWarnings(q{
+unittest
+{{
+}}
+	}, sac);
+
 
 	stderr.writeln("Unittest for Allman passed.");
 }


### PR DESCRIPTION
It seems like I have tested Phobos yesterday with a wrong dscanner binary.
However, there's only one small need for amendment that I found.

Apparently e.g in `std/experimental/allocator/common.d` this brace style seems to be popular for `static if`:

```d
        static if (hasMember!(A, "alignedAllocate"))
        {{
             auto b3 = a.alignedAllocate(1, 256);
             assert(b3.length <= 1);
             assert(b3.ptr.alignedAt(256));
             assert(a.alignedReallocate(b3, 2, 512));
             assert(b3.ptr.alignedAt(512));
             static if (hasMember!(A, "alignedDeallocate"))
             {
                 a.alignedDeallocate(b3);
             }
        }}
```