### PR TITLE
update libdparse

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -10,7 +10,7 @@
 		"StdLoggerDisableWarning"
 	],
 	"dependencies": {
-		"libdparse": "~>0.7.0",
+		"libdparse": "~>0.7.1-beta.2",
 		"dsymbol": "~>0.2.0",
 		"inifiled": ">=0.0.6",
 		"emsi_containers": "~>0.5.3",


### PR DESCRIPTION
There's a deprecation message when it's build with dmd-nightly. It matches to something that's fixed in the latest dparse version. The version used by D-Scanner was ~~quite~~ a bit outdated anyway.