### PR TITLE
Workaround 17506 by excluding treemap.d

### DIFF
--- a/makefile
+++ b/makefile
@@ -5,6 +5,8 @@ DMD := $(DC)
 GDC := gdc
 LDC := ldc2
 OBJ_DIR := obj
+# Exclusion of treemap is due to https://issues.dlang.org/show_bug.cgi?id=17506
+# More details: https://github.com/dlang-community/D-Scanner/issues/461
 SRC := \
 	$(shell find containers/src -name "*.d" -not -name 'treemap.d')\
 	$(shell find dsymbol/src -name "*.d")\

--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ GDC := gdc
 LDC := ldc2
 OBJ_DIR := obj
 SRC := \
-	$(shell find containers/src -name "*.d")\
+	$(shell find containers/src -name "*.d" -not -name 'treemap.d')\
 	$(shell find dsymbol/src -name "*.d")\
 	$(shell find inifiled/source/ -name "*.d")\
 	$(shell find libdparse/src/std/experimental/ -name "*.d")\


### PR DESCRIPTION
In theory this should fix Travis for now. An alternative would be to use `allow_failures`