### PR TITLE
set more def bucket count to get better perfs on huge modules

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -169,7 +169,7 @@ else
 
 	immutable usingStdin = args.length == 1;
 
-	StringCache cache = StringCache(StringCache.defaultBucketCount);
+	StringCache cache = StringCache(0xFFFF);
 	if (defaultConfig)
 	{
 		string s = getConfigurationLocation();


### PR DESCRIPTION
This is related to https://github.com/dlang-community/libdparse/issues/147.
Improvement is verified on prime_4m.d.