### PR TITLE
Revert "Workaround 17506 by excluding treemap.d (#459)"

### DIFF
--- a/makefile
+++ b/makefile
@@ -5,10 +5,8 @@ DMD := $(DC)
 GDC := gdc
 LDC := ldc2
 OBJ_DIR := obj
-# Exclusion of treemap is due to https://issues.dlang.org/show_bug.cgi?id=17506
-# More details: https://github.com/dlang-community/D-Scanner/issues/461
 SRC := \
-	$(shell find containers/src -name "*.d" -not -name 'treemap.d')\
+	$(shell find containers/src -name "*.d")\
 	$(shell find dsymbol/src -name "*.d")\
 	$(shell find inifiled/source/ -name "*.d")\
 	$(shell find libdparse/src/std/experimental/ -name "*.d")\


### PR DESCRIPTION
This reverts commit 80b831addaece9f0c4f65b27eb501767db1f7fb1.
The workaround is no longer necessary as the problematic
feature has been reverted from dmd-nightly.