### PR TITLE
Fix AssertError on unknown label in unused_label

### DIFF
--- a/src/analysis/unused_label.d
+++ b/src/analysis/unused_label.d
@@ -143,8 +143,11 @@ private:
 	{
 		foreach (label; current.byValue())
 		{
-			assert(label.line != size_t.max && label.column != size_t.max);
-			if (!label.used)
+			if (label.line == size_t.max || label.column == size_t.max)
+			{
+				// TODO: handle unknown labels
+			}
+			else if (!label.used)
 			{
 				addErrorMessage(label.line, label.column, "dscanner.suspicious.unused_label",
 						"Label \"" ~ label.name ~ "\" is not used.");
@@ -222,6 +225,25 @@ unittest
 		{
 			asm { mov RAX,1;}
 			lbl: // [warn]: Label "lbl" is not used.
+		}
+	}c, sac);
+
+	// from std.math
+	assertAnalyzerWarnings(q{
+		real polyImpl() {
+			asm {
+				jecxz return_ST;
+		    }
+		}
+	}c, sac);
+
+	// a label might be hard to find, e.g. in a mixin
+	assertAnalyzerWarnings(q{
+		real polyImpl() {
+			mixin("return_ST: return 1;");
+			asm {
+				jecxz return_ST;
+		    }
 		}
 	}c, sac);
 


### PR DESCRIPTION
I tried to run Dscanner with all checks enabled (aka empty config) on Phobos (this might be a good CI check).

For now, I simply inserted a TODO when a unknown label is used, but I will open a new issue, s.t. it's not forgotten.