### PR TITLE
Make Dscanner usable as a library

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -4,7 +4,7 @@
 	"copyright": "© Brian Schott",
 	"authors": ["Brian Schott"],
 	"license" : "Boost Software License - Version 1.0",
-	"targetType": "executable",
+	"targetType": "autodetect",
 	"versions": [
 		"built_with_dub",
 		"StdLoggerDisableWarning"


### PR DESCRIPTION
Similarly to https://github.com/dlang-community/dfmt/pull/281

I found that even now [it's possible to use Dscanner a library](https://gist.github.com/wilzbach/e5be1b0cbf21fba8bee5d4180874f6bf) - though of course with a lot of alpha warrior energy ;-)
Eventually we should also move all modules into `dscanner.*`

(the linked Gist won't work as of now as it depends on https://github.com/economicmodeling/libddoc/pull/31, https://github.com/dlang-community/D-Scanner/pull/466 and this PR)