### PR TITLE
Temporarily disable the unused check for DScanner

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -23,7 +23,7 @@ if_else_same_check="enabled"
 ; Checks for some problems with constructors
 constructor_check="enabled"
 ; Checks for unused variables and function parameters
-unused_variable_check="enabled"
+unused_variable_check="disabled"
 ; Checks for unused labels
 unused_label_check="enabled"
 ; Checks for duplicate attributes


### PR DESCRIPTION
In  `has_public_example` there are a few false-positives due to mixins, e.g.

```d
	bool hasDittos(Decl)(const Decl decl)
	{
		foreach (property; possibleDeclarations)
			if (mixin("hasDitto(decl." ~ property ~ ")"))
				return true;
		return false;
	}
```

This is a hotfix to get master green on Travis. Of course, we should try to enable this check.