### PR TITLE
Check for function parameters in mixins

### DIFF
--- a/src/dscanner/analysis/unused.d
+++ b/src/dscanner/analysis/unused.d
@@ -412,6 +412,8 @@ private:
 		{
 			if (!uu.isRef && tree.length > 1)
 			{
+			    if (uu.uncertain)
+			        continue;
 				immutable string certainty = uu.uncertain ? " might not be used."
 					: " is never used.";
 				immutable string errorMessage = (uu.isParameter ? "Parameter " : "Variable ")

--- a/src/dscanner/analysis/unused.d
+++ b/src/dscanner/analysis/unused.d
@@ -234,11 +234,16 @@ class UnusedVariableCheck : BaseAnalyzer
 			{
 				foreach (part; matchAll(primary.primary.text, re))
 				{
-					immutable size_t treeIndex = tree.length - 1;
-					auto uu = UnUsed(part.hit);
-					auto r = tree[treeIndex].equalRange(&uu);
-					if (!r.empty)
-						r.front.uncertain = true;
+					void checkTree(in size_t treeIndex)
+					{
+						auto uu = UnUsed(part.hit);
+						auto r = tree[treeIndex].equalRange(&uu);
+						if (!r.empty)
+							r.front.uncertain = true;
+					}
+					checkTree(tree.length - 1);
+					if (tree.length >= 2)
+						checkTree(tree.length - 2);
 				}
 			}
 		}
@@ -525,6 +530,11 @@ private:
 		cb1(3);
 		auto cb2 = delegate(size_t a) {}; // [warn]: Parameter a is never used.
 		cb2(3);
+	}
+	
+	bool hasDittos(int decl)
+	{
+		mixin("decl++;");
 	}
 
 	}c, sac);


### PR DESCRIPTION
This isn't a proper fix for the unused variable errors in has_public_example, but me publicly experimenting with it.

@BBasile Is there a particular reason why you still trigger error messages (even if the message is detected as "uncertain"?)