### PR TITLE
Apply selective filtering for has_public_example as well

### DIFF
--- a/src/analysis/run.d
+++ b/src/analysis/run.d
@@ -477,7 +477,7 @@ MessageSet analyze(string fileName, const Module m, const StaticAnalysisConfig a
 		checks ~= new RedundantAttributesCheck(fileName, moduleScope,
 		analysisConfig.redundant_attributes_check == Check.skipTests && !ut);
 
-	if (analysisConfig.has_public_example!= Check.disabled)
+	if (moduleName.shouldRun!"has_public_example"(analysisConfig))
 		checks ~= new HasPublicExampleCheck(fileName, moduleScope,
 		analysisConfig.has_public_example == Check.skipTests && !ut);
 


### PR DESCRIPTION
`has_public_example` has been added while the selective filtering PR as sitting in the queue and interestingly there were no merge conflicts.
Anyhow, we do want to allow filtering for `has_public_example` as well.