### PR TITLE
No longer uses deprecated string.removechars

### DIFF
--- a/src/analysis/range.d
+++ b/src/analysis/range.d
@@ -141,9 +141,10 @@ private:
 	long parseNumber(string te)
 	{
 		import std.conv : to;
-		import std.string : removechars;
+		import std.regex : ctRegex, replaceAll;
 
-		string t = te.removechars("_uUlL");
+		enum re = ctRegex!("[_uUlL]", "");
+		string t = te.replaceAll(re, "");
 		if (t.length > 2)
 		{
 			if (t[1] == 'x' || t[1] == 'X')


### PR DESCRIPTION
`src/analysis/range.d` previously used the deprecated `std.string.removechars`.  While it isn't scheduled for removal for almost a year, it's good to stay up to date.
The proposed change uses statically-compiled regular expressions instead.