### PR TITLE
Add a findDeclarationOf overload that takes a callback

### DIFF
--- a/src/symbol_finder.d
+++ b/src/symbol_finder.d
@@ -16,7 +16,8 @@ import std.functional : toDelegate;
 
 void findDeclarationOf(File output, string symbolName, string[] fileNames)
 {
-	findDeclarationOf((string fileName, size_t line, size_t column) {
+	findDeclarationOf((string fileName, size_t line, size_t column)
+	{
 		output.writefln("%s(%d:%d)", fileName, line, column);
 	}, symbolName, fileNames);
 }

--- a/src/symbol_finder.d
+++ b/src/symbol_finder.d
@@ -16,6 +16,21 @@ import std.functional : toDelegate;
 
 void findDeclarationOf(File output, string symbolName, string[] fileNames)
 {
+	findDeclarationOf((string fileName, size_t line, size_t column) {
+		output.writefln("%s(%d:%d)", fileName, line, column);
+	}, symbolName, fileNames);
+}
+
+/// Delegate that gets called every time a declaration gets found
+alias OutputHandler = void delegate(string fileName, size_t line, size_t column);
+
+/// Finds all declarations of a symbol in the given fileNames and calls a handler on every occurence.
+/// Params:
+///   output = Callback which gets called when a declaration is found
+///   symbolName = Symbol name to search for
+///   fileNames = An array of file names which might contain stdin to read from stdin
+void findDeclarationOf(scope OutputHandler output, string symbolName, string[] fileNames)
+{
 	import std.array : uninitializedArray, array;
 	import std.conv : to;
 
@@ -46,7 +61,7 @@ void doNothing(string, size_t, size_t, string, bool)
 
 class FinderVisitor : ASTVisitor
 {
-	this(File output, string symbolName)
+	this(OutputHandler output, string symbolName)
 	{
 		this.output = output;
 		this.symbolName = symbolName;
@@ -62,19 +77,19 @@ class FinderVisitor : ASTVisitor
 	override void visit(const EnumDeclaration dec)
 	{
 		if (dec.name.text == symbolName)
-			output.writefln("%s(%d:%d)", fileName, dec.name.line, dec.name.column);
+			output(fileName, dec.name.line, dec.name.column);
 	}
 
 	override void visit(const AnonymousEnumMember member)
 	{
 		if (member.name.text == symbolName)
-			output.writefln("%s(%d:%d)", fileName, member.name.line, member.name.column);
+			output(fileName, member.name.line, member.name.column);
 	}
 
 	override void visit(const EnumMember member)
 	{
 		if (member.name.text == symbolName)
-			output.writefln("%s(%d:%d)", fileName, member.name.line, member.name.column);
+			output(fileName, member.name.line, member.name.column);
 	}
 
 	override void visit(const AliasDeclaration dec)
@@ -84,13 +99,13 @@ class FinderVisitor : ASTVisitor
 			foreach (ident; dec.identifierList.identifiers)
 			{
 				if (ident.text == symbolName)
-					output.writefln("%s(%d:%d)", fileName, ident.line, ident.column);
+					output(fileName, ident.line, ident.column);
 			}
 		}
 		foreach (initializer; dec.initializers)
 		{
 			if (initializer.name.text == symbolName)
-				output.writefln("%s(%d:%d)", fileName, initializer.name.line,
+				output(fileName, initializer.name.line,
 						initializer.name.column);
 		}
 	}
@@ -98,7 +113,7 @@ class FinderVisitor : ASTVisitor
 	override void visit(const Declarator dec)
 	{
 		if (dec.name.text == symbolName)
-			output.writefln("%s(%d:%d)", fileName, dec.name.line, dec.name.column);
+			output(fileName, dec.name.line, dec.name.column);
 	}
 
 	override void visit(const AutoDeclaration ad)
@@ -106,7 +121,7 @@ class FinderVisitor : ASTVisitor
 		foreach (part; ad.parts)
 		{
 			if (part.identifier.text == symbolName)
-				output.writefln("%s(%d:%d)", fileName, part.identifier.line, part.identifier.column);
+				output(fileName, part.identifier.line, part.identifier.column);
 		}
 	}
 
@@ -119,14 +134,14 @@ class FinderVisitor : ASTVisitor
 		override void visit(const T t)
 		{
 			if (t.name.text == symbolName)
-				output.writefln("%s(%d:%d)", fileName, t.name.line, t.name.column);
+				output(fileName, t.name.line, t.name.column);
 			t.accept(this);
 		}
 	}
 
 	alias visit = ASTVisitor.visit;
 
-	File output;
+	OutputHandler output;
 	string symbolName;
 	string fileName;
 }


### PR DESCRIPTION
This makes getting the declarations when working with dscanner as a library much easier. Another possible improvement for the future could be directly passing File objects or an input range of Files.

Also this removed a bit of code duplication where there were so many writefln calls.