### PR TITLE
update dparse - could stuck because of AA lit bug

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -12,7 +12,7 @@
     "StdLoggerDisableWarning"
   ],
   "dependencies" : {
-    "libdparse" : "~>0.7.1-beta.7",
+    "libdparse" : "~>0.7.1",
     "dsymbol" : "~>0.2.6",
     "inifiled" : ">=1.0.2",
     "emsi_containers" : "~>0.5.3",


### PR DESCRIPTION
A bug that's fixed in 0.7.1 could make D-Scanner falling into an infinite loop, see https://github.com/dlang-community/libdparse/issues/167