### PR TITLE
Compile DScanner with -fPIC

### DIFF
--- a/makefile
+++ b/makefile
@@ -21,7 +21,7 @@ INCLUDE_PATHS = \
 	-Ilibddoc/src
 VERSIONS =
 DEBUG_VERSIONS = -version=dparse_verbose
-DMD_FLAGS = -w -inline -release -O -J. -od${OBJ_DIR} -version=StdLoggerDisableWarning
+DMD_FLAGS = -w -inline -release -O -J. -od${OBJ_DIR} -version=StdLoggerDisableWarning -fPIC
 DMD_TEST_FLAGS = -w -g -J. -version=StdLoggerDisableWarning
 
 all: dmdbuild
@@ -32,7 +32,7 @@ githash:
 	git log -1 --format="%H" > githash.txt
 
 debug:
-	${DC} -w -g -J. -ofdsc ${VERSIONS} ${DEBUG_VERSIONS} ${INCLUDE_PATHS} ${SRC}
+	${DC} -fPIC -w -g -J. -ofdsc ${VERSIONS} ${DEBUG_VERSIONS} ${INCLUDE_PATHS} ${SRC}
 
 dmdbuild: githash $(SRC)
 	mkdir -p bin


### PR DESCRIPTION
[By default, DMD passes `-fPIC` to the linker](https://github.com/dlang/dmd/blob/master/ini/linux/bin64/dmd.conf), but sadly the development build of DMD doesn't: https://github.com/dlang/dmd/pull/7002

As the regarding PR won't be merged in the foreseeable future, I think it's best to simply add the flag to the Makefile. 