### PR TITLE
Compile dscanner with -fPIC

### DIFF
--- a/makefile
+++ b/makefile
@@ -21,7 +21,7 @@ INCLUDE_PATHS = \
 	-Ilibddoc/src
 VERSIONS =
 DEBUG_VERSIONS = -version=dparse_verbose
-DMD_FLAGS = -w -inline -release -O -J. -od${OBJ_DIR} -version=StdLoggerDisableWarning
+DMD_FLAGS = -w -inline -release -O -J. -od${OBJ_DIR} -version=StdLoggerDisableWarning -fPIC
 DMD_TEST_FLAGS = -w -g -J. -version=StdLoggerDisableWarning
 
 all: dmdbuild
@@ -32,7 +32,7 @@ githash:
 	git log -1 --format="%H" > githash.txt
 
 debug:
-	${DC} -w -g -J. -ofdsc ${VERSIONS} ${DEBUG_VERSIONS} ${INCLUDE_PATHS} ${SRC}
+	${DC} -fPIC -w -g -J. -ofdsc ${VERSIONS} ${DEBUG_VERSIONS} ${INCLUDE_PATHS} ${SRC}
 
 dmdbuild: githash $(SRC)
 	mkdir -p bin


### PR DESCRIPTION
https://github.com/dlang-community/D-Scanner/pull/523, but for `phobos`

This is needed to compile D-Scanner on a hardened distro through the `make -f posix.mak style` target at Phobos.