### PR TITLE
update libdparse to prevent case of OutOfMem

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -12,7 +12,7 @@
     "StdLoggerDisableWarning"
   ],
   "dependencies" : {
-    "libdparse" : "~>0.7.2-alpha.1",
+    "libdparse" : "~>0.7.2-alpha.2",
     "dsymbol" : "~>0.2.6",
     "inifiled" : ">=1.0.2",
     "emsi_containers" : "~>0.5.3",


### PR DESCRIPTION
Related to https://github.com/dlang-community/libdparse/issues/176