### PR TITLE
fix #533 - "Could be declared const" should be avoided for declarations with "new"

### DIFF
--- a/src/analysis/unmodified.d
+++ b/src/analysis/unmodified.d
@@ -58,6 +58,8 @@ class UnmodifiedFinder : BaseAnalyzer
 			{
 				if (initializedFromCast(d.initializer))
 					continue;
+				if (initializedFromNew(d.initializer))
+					continue;
 				tree[$ - 1].insert(new VariableInfo(d.name.text, d.name.line,
 						d.name.column, isValueTypeSimple(dec.type)));
 			}
@@ -76,6 +78,8 @@ class UnmodifiedFinder : BaseAnalyzer
 			foreach (part; autoDeclaration.parts)
 			{
 				if (initializedFromCast(part.initializer))
+					continue;
+				if (initializedFromNew(part.initializer))
 					continue;
 				tree[$ - 1].insert(new VariableInfo(part.identifier.text,
 						part.identifier.line, part.identifier.column));
@@ -211,6 +215,19 @@ private:
 		}
 	}
 
+	bool initializedFromNew(const Initializer initializer)
+	{
+		if (initializer.nonVoidInitializer &&
+			initializer.nonVoidInitializer.assignExpression &&
+			cast(UnaryExpression) initializer.nonVoidInitializer.assignExpression)
+		{
+			const UnaryExpression ue =
+				cast(UnaryExpression) initializer.nonVoidInitializer.assignExpression;
+			return ue.newExpression !is null;
+		}
+		else return false;
+	}
+
 	bool initializedFromCast(const Initializer initializer)
 	{
 		import std.typecons : scoped;
@@ -325,6 +342,12 @@ bool isValueTypeSimple(const Type type) pure nothrow @nogc
     StaticAnalysisConfig sac = disabledConfig();
     sac.could_be_immutable_check = Check.enabled;
 
+	// fails
+
+	assertAnalyzerWarnings(q{
+        void foo(){int i = 1;} // [warn]: Variable i is never modified and could have been declared const or immutable.
+    }, sac);
+
     // pass
 
     assertAnalyzerWarnings(q{
@@ -337,6 +360,14 @@ bool isValueTypeSimple(const Type type) pure nothrow @nogc
 
 	assertAnalyzerWarnings(q{
         void foo(){enum i = 1;}
+    }, sac);
+
+	assertAnalyzerWarnings(q{
+        void foo(){E e = new E;}
+    }, sac);
+
+	assertAnalyzerWarnings(q{
+        void foo(){auto e = new E;}
     }, sac);
 
 }

--- a/src/analysis/unmodified.d
+++ b/src/analysis/unmodified.d
@@ -225,7 +225,7 @@ private:
 				cast(UnaryExpression) initializer.nonVoidInitializer.assignExpression;
 			return ue.newExpression !is null;
 		}
-		else return false;
+		return false;
 	}
 
 	bool initializedFromCast(const Initializer initializer)


### PR DESCRIPTION
see #533 for rationale.