### PR TITLE
Upload built binaries to GitHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,30 @@
 sudo: false
 language: d
 d:
-  - dmd-nightly
-  - dmd-beta
-  - dmd
-  - ldc-beta
-  - ldc
+- dmd-nightly
+- dmd-beta
+- dmd
+- ldc-beta
+- ldc
 os:
-  - linux
-  - osx
+- linux
+- osx
 env:
-  - BUILD=
-  - BUILD=dub
-
-script: ./.travis.sh
+- BUILD=
+- BUILD=dub
+script: "./.travis.sh"
+jobs:
+  include:
+  - stage: GitHub Release
+    d: ldc
+    os: linux
+    script: echo "Deploying to GitHub releases ..." && make ldcbuild
+    deploy:
+      provider: releases
+      api_key:
+        secure: pbrrm6E0SPfVwt9g+e/ZFQfrmRuGBNA6KwMMLUhI+2+kbRzNquxvrYAUC7YcRX7xiRL/gugKHmOXEi1Dv9IEdSQ732M06H7ikZT9T9oQWYbsZzmVICBWgIovyM8XIPpVAwP8D7jq0JgMiBicqfEZfoz2SIJjo6aYbyQbCASCu8U=
+      file: bin/dscanner
+      skip_cleanup: true
+      on:
+        repo: dlang-community/D-Scanner
+        tags: true


### PR DESCRIPTION
For now Linux only. However, it can be used with [OSX too](https://github.com/jacob-carlborg/remarkify/blob/master/.travis.yml)


See also:
- https://docs.travis-ci.com/user/deployment/releases/
- https://docs.travis-ci.com/user/build-stages/deploy-github-releases

I will directly merge this as (1) we talked about this in the past and no one objected https://github.com/dlang-community/discussions/issues/9 and (2) it's an experiment anyways and (3) this just modifies the `.travis.yml` - no actual source code changes are happening.
I will also add a new tag afterwards to test this.