### PR TITLE
Make splitting of lines for testing agnostic of a specific style.

### DIFF
--- a/src/analysis/helpers.d
+++ b/src/analysis/helpers.d
@@ -61,7 +61,7 @@ void assertAnalyzerWarnings(string code, const StaticAnalysisConfig config,
 
 	// Run the code and get any warnings
 	MessageSet rawWarnings = analyze("test", m, config, moduleCache, tokens);
-	string[] codeLines = code.split(newline);
+	string[] codeLines = code.splitLines();
 
 	// Get the warnings ordered by line
 	string[size_t] warnings;

--- a/src/analysis/helpers.d
+++ b/src/analysis/helpers.d
@@ -50,7 +50,6 @@ void assertAnalyzerWarnings(string code, const StaticAnalysisConfig config,
 {
 	import analysis.run : parseModule;
 	import dparse.lexer : StringCache, Token;
-	import std.ascii : newline;
 
 	StringCache cache = StringCache(StringCache.defaultBucketCount);
 	RollbackAllocator r;


### PR DESCRIPTION
So that `\n` can be used on Windows.