### PR TITLE
Update LDC download url to use new format.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,7 +66,7 @@ install:
                 $latest = $version;
                 $url = "https://github.com/ldc-developers/ldc/releases/download/v$($version)/ldc2-$($version)-win64-msvc.zip";
             }
-            $env:PATH += ";C:\ldc2-$($latest)-win64-msvc\bin";
+            $env:PATH += ";C:\ldc2-$($latest)-windows-x64\bin";
             $env:DC = "ldc2";
             return $url;
         }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,9 +16,9 @@ environment:
   #- DC: ldc
     #DVersion: beta
     #arch: x86
-  #- DC: ldc
-    #DVersion: beta
-    #arch: x64
+  - DC: ldc
+    DVersion: beta
+    arch: x64
   #- DC: ldc
     #DVersion: stable
     #arch: x86
@@ -58,10 +58,10 @@ install:
             $version = $env:DVersion;
             if($version -eq "stable") {
                 $latest = (Invoke-WebRequest "https://ldc-developers.github.io/LATEST").toString().replace("`n","").replace("`r","");
-                $url = "https://github.com/ldc-developers/ldc/releases/download/v$($latest)/ldc2-$($latest)-win64-msvc.zip";
+                $url = "https://github.com/ldc-developers/ldc/releases/download/v$($latest)/ldc2-$($latest)-windows-x64.7z";
             }elseif($version -eq "beta") {
                 $latest = (Invoke-WebRequest "https://ldc-developers.github.io/LATEST_BETA").toString().replace("`n","").replace("`r","");
-                $url = "https://github.com/ldc-developers/ldc/releases/download/v$($latest)/ldc2-$($latest)-win64-msvc.zip";
+                $url = "https://github.com/ldc-developers/ldc/releases/download/v$($latest)/ldc2-$($latest)-windows-x64.7z";
             } else {
                 $latest = $version;
                 $url = "https://github.com/ldc-developers/ldc/releases/download/v$($version)/ldc2-$($version)-win64-msvc.zip";
@@ -87,10 +87,10 @@ install:
               echo "downloading ...";
               $url = ResolveLatestLDC;
               echo $url;
-              Invoke-WebRequest $url -OutFile "c:\ldc.zip";
+              Invoke-WebRequest $url -OutFile "c:\ldc.7z";
               echo "finished.";
               pushd c:\\;
-              7z x ldc.zip > $null;
+              7z x ldc.7z > $null;
               popd;
             }
         }


### PR DESCRIPTION
LDC stable has been released that uses the new URL format.