### PR TITLE
Make visiting alias public

### DIFF
--- a/src/outliner.d
+++ b/src/outliner.d
@@ -13,6 +13,8 @@ import std.conv;
 
 class Outliner : ASTVisitor
 {
+	alias visit = ASTVisitor.visit;
+
 	this(File output)
 	{
 		this.output = output;
@@ -171,8 +173,6 @@ private:
 	}
 
 	int indentLevel;
-
-	alias visit = ASTVisitor.visit;
 
 	File output;
 }


### PR DESCRIPTION
Making the visiting alias private makes it so that the visit(Module) overload is not visible outside the Outliner class. The code worked up until now due to a bug [1] in the compiler.

[1] https://github.com/dlang/dmd/pull/7766