### PR TITLE
Disable nightly + beta builds for AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,12 @@
 platform: x64
 environment:
  matrix:
-  - DC: dmd
-    DVersion: beta
-    arch: x64
-  - DC: dmd
-    DVersion: beta
-    arch: x86
+  #- DC: dmd
+    #DVersion: beta
+    #arch: x64
+  #- DC: dmd
+    #DVersion: beta
+    #arch: x86
   - DC: dmd
     DVersion: stable
     arch: x64
@@ -16,9 +16,9 @@ environment:
   #- DC: ldc
     #DVersion: beta
     #arch: x86
-  - DC: ldc
-    DVersion: beta
-    arch: x64
+  #- DC: ldc
+    #DVersion: beta
+    #arch: x64
   #- DC: ldc
     #DVersion: stable
     #arch: x86


### PR DESCRIPTION
The less builds we use on AppVeyor, the less can fail!