### PR TITLE
Fix Issue 18409 - DScanner SEGFAULTS on CircleCI

### DIFF
--- a/src/analysis/incorrect_infinite_range.d
+++ b/src/analysis/incorrect_infinite_range.d
@@ -45,7 +45,8 @@ class IncorrectInfiniteRangeCheck : BaseAnalyzer
 		if (fb.bodyStatement !is null)
 			visit(fb.bodyStatement.blockStatement);
 		else
-			visit(fb.blockStatement);
+			if (fb.blockStatement !is null)
+				visit(fb.blockStatement);
 	}
 
 	override void visit(const BlockStatement bs)
@@ -109,6 +110,12 @@ unittest
 	{
 		return false;
 	}
+
+	// https://issues.dlang.org/show_bug.cgi?id=18409
+	struct Foo
+	{
+		~this() nothrow @nogc;
+	}
 }
 
 bool empty() { return false; }
@@ -116,5 +123,6 @@ class C { bool empty() { return false; } } // [warn]: %1$s
 
 }c
 			.format(IncorrectInfiniteRangeCheck.MESSAGE), sac);
+
 	stderr.writeln("Unittest for IncorrectInfiniteRangeCheck passed.");
 }


### PR DESCRIPTION
Trivial failure that broke our Phobos CI. It's already on the `phobos` branch.

It occurred here: https://github.com/dlang/phobos/blob/5854e6150035b18439e752b6c851f9478d521508/std/experimental/allocator/building_blocks/ascending_page_allocator.d#L277