### PR TITLE
Allow customizing the style check messages' format

### DIFF
--- a/src/analysis/helpers.d
+++ b/src/analysis/helpers.d
@@ -54,7 +54,7 @@ void assertAnalyzerWarnings(string code, const StaticAnalysisConfig config,
 	StringCache cache = StringCache(StringCache.defaultBucketCount);
 	RollbackAllocator r;
 	const(Token)[] tokens;
-	const(Module) m = parseModule(file, cast(ubyte[]) code, &r, cache, false, tokens);
+	const(Module) m = parseModule(file, cast(ubyte[]) code, &r, defaultErrorFormat, cache, false, tokens);
 
 	auto moduleCache = ModuleCache(new CAllocatorImpl!Mallocator);
 

--- a/src/main.d
+++ b/src/main.d
@@ -67,6 +67,7 @@ else
 	string[] importPaths;
 	bool printVersion;
 	bool explore;
+	string errorFormat;
 
 	try
 	{
@@ -94,7 +95,8 @@ else
 				"version", &printVersion,
 				"muffinButton", &muffin,
 				"explore", &explore,
-				"skipTests", &skipTests);
+				"skipTests", &skipTests,
+				"errorFormat|f", &errorFormat);
 		//dfmt on
 	}
 	catch (ConvException e)
@@ -140,6 +142,9 @@ else
 			write(DSCANNER_VERSION, " ", GIT_HASH);
 		return 0;
 	}
+
+    if (!errorFormat.length)
+        errorFormat = defaultErrorFormat;
 
 	const(string[]) absImportPaths = importPaths.map!(a => a.absolutePath()
 			.buildNormalizedPath()).array();
@@ -234,11 +239,11 @@ else
 		if (report)
 			generateReport(expandArgs(args), config, cache, moduleCache);
 		else
-			return analyze(expandArgs(args), config, cache, moduleCache, true) ? 1 : 0;
+			return analyze(expandArgs(args), config, errorFormat, cache, moduleCache, true) ? 1 : 0;
 	}
 	else if (syntaxCheck)
 	{
-		return .syntaxCheck(usingStdin ? ["stdin"] : expandArgs(args), cache, moduleCache) ? 1 : 0;
+		return .syntaxCheck(usingStdin ? ["stdin"] : expandArgs(args), errorFormat, cache, moduleCache) ? 1 : 0;
 	}
 	else
 	{


### PR DESCRIPTION
Hi,

This patch allows external tools to parse the diagnostics more easily. The code that compiles the format is the most stupid&simple I could think of, but maybe there's a more idiomatic way to do it.

Closes #377 