### PR TITLE
Add a temporary function that warns or patches the old INI section

### DIFF
--- a/src/dscanner/main.d
+++ b/src/dscanner/main.d
@@ -395,8 +395,8 @@ Options:
     --skipTests
         Does not analyze in the unittests. Only works if --styleCheck.,
 
-	--patchConfig
-		Patches the configuration file passed as parameter for v0.5.0.`,
+    --patchConfig
+        Patches the configuration file passed as parameter for v0.5.0.`,
 
     programName);
 }


### PR DESCRIPTION
After thinking more about the upcoming breaking change i think that finally the changelog and a forum announce could be not enough. This PR makes D-Scanner exit if the old INI section is found, with instruction about how to patch.