### PR TITLE
Fix #568 - Add multi-line support for .dscanner.ini

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -14,7 +14,7 @@
   "dependencies" : {
     "libdparse": "~>0.8.0-alpha.5",
     "dsymbol" : "~>0.3.0-alpha.3",
-    "inifiled" : ">=1.0.2",
+    "inifiled" : "~>1.1.0",
     "emsi_containers" : "~>0.6.0",
     "libddoc" : "~>0.3.0-beta.1",
     "stdx-allocator" : "~>2.77.0"


### PR DESCRIPTION
A simple bump as https://github.com/burner/inifiled/pull/10 as been merged now.