### PR TITLE
Improve the binary release building (Linux, OSX)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,31 @@ env:
 script: "./.travis.sh"
 jobs:
   include:
-  - stage: GitHub Release
-    d: ldc
-    os: linux
-    script: echo "Deploying to GitHub releases ..." && make ldcbuild
-    deploy:
-      provider: releases
-      api_key:
-        secure: pbrrm6E0SPfVwt9g+e/ZFQfrmRuGBNA6KwMMLUhI+2+kbRzNquxvrYAUC7YcRX7xiRL/gugKHmOXEi1Dv9IEdSQ732M06H7ikZT9T9oQWYbsZzmVICBWgIovyM8XIPpVAwP8D7jq0JgMiBicqfEZfoz2SIJjo6aYbyQbCASCu8U=
-      file: bin/dscanner
-      skip_cleanup: true
-      on:
-        repo: dlang-community/D-Scanner
-        tags: true
+    - stage: GitHub Release
+      if: tag IS present
+      d: ldc
+      os: linux
+      script: echo "Deploying to GitHub releases ..." && make release
+      deploy:
+        provider: releases
+        api_key: $GH_REPO_TOKEN
+        file_glob: true
+        file: bin/dscanner-*.tar.gz
+        skip_cleanup: true
+        on:
+          repo: dlang-community/D-Scanner
+          tags: true
+    - stage: GitHub Release
+      if: tag IS present
+      d: ldc
+      os: osx
+      script: echo "Deploying to GitHub releases ..." && make release
+      deploy:
+        provider: releases
+        api_key: $GH_REPO_TOKEN
+        file_glob: true
+        file: bin/dscanner-*.tar.gz
+        skip_cleanup: true
+        on:
+          repo: dlang-community/D-Scanner
+          tags: true

--- a/makefile
+++ b/makefile
@@ -72,3 +72,27 @@ clean:
 report: all
 	dscanner --report src > src/dscanner-report.json
 	sonar-runner
+
+.ONESHELL:
+release:
+	@set -eux -o pipefail
+	VERSION=$$(git describe --abbrev=0 --tags)
+	ARCH="$${ARCH:-64}"
+	unameOut="$$(uname -s)"
+	case "$$unameOut" in
+	    Linux*) OS=linux; ;;
+	    Darwin*) OS=osx; ;;
+	    *) echo "Unknown OS: $$unameOut"; exit 1
+	esac
+
+	case "$$ARCH" in
+	    64) ARCH_SUFFIX="x86_64";;
+	    32) ARCH_SUFFIX="x86";;
+	    *) echo "Unknown ARCH: $$ARCH"; exit 1
+	esac
+
+	archiveName="dscanner-$$VERSION-$$OS-$$ARCH_SUFFIX.tar.gz"
+
+	echo "Building $$archiveName"
+	${MAKE} ldcbuild
+	tar cvfz "bin/$$archiveName" -C bin dscanner


### PR DESCRIPTION
Improves the existing process to upload binaries to GitHub releases, e.g.

https://github.com/dlang-community/D-Scanner/releases/tag/v0.5.0-rc1

See also:
- https://github.com/dlang-community/D-Scanner/pull/539
- https://github.com/dlang/dub/pull/1369

I don't use nor have Windows, so I'm not really qualified for that one, but here's an example from the DLang Installer:

https://github.com/dlang/installer/pull/284/files