### PR TITLE
Fix Make's shell to Bash

### DIFF
--- a/makefile
+++ b/makefile
@@ -27,6 +27,7 @@ VERSIONS =
 DEBUG_VERSIONS = -version=dparse_verbose
 DMD_FLAGS = -w -inline -release -O -J. -od${OBJ_DIR} -version=StdLoggerDisableWarning
 DMD_TEST_FLAGS = -w -g -J. -version=StdLoggerDisableWarning
+SHELL:=/bin/bash
 
 all: dmdbuild
 ldc: ldcbuild


### PR DESCRIPTION
So when I moved the new release bundling from the bash script into the Makefile, I "only" tested it locally and just assumed that it work on Travis too (as it currently does for dub).

It turns out that Make on Travis defaults to `/bin/sh` which points to `dash` on Ubuntu :/

See also: https://travis-ci.org/dlang-community/D-Scanner/jobs/360467457