### PR TITLE
[WIP] Fix #493 - Add a check for documented symbols that aren't public

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Note that the "--skipTests" option is the equivalent of changing each
 * Asserts without an explanatory message. By default disabled.
 * Indentation of if constraints
 * Check that `@trusted` is not applied to a whole scope. Trusting a whole scope can be a problem when new declarations are added and if they are not verified manually to be trustable.
+* Documented symbols are public
 
 #### Wishlist
 
@@ -228,7 +229,7 @@ the given source file to standard output in XML format.
 ```sh
 $ dscanner --ast helloworld.d
 ```
-	
+
 ```xml
 <module>
 <declaration>

--- a/src/dscanner/analysis/common.d
+++ b/src/dscanner/analysis/common.d
@@ -1,0 +1,54 @@
+// Copyright (c) 2018, dlang-community
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+module dscanner.analysis.common;
+
+import dparse.ast;
+
+/// Checks whether a declaration is really a declaration or just a label
+bool isLabel(const Declaration decl)
+{
+	import std.meta : AliasSeq;
+	alias properties = AliasSeq!(
+		"aliasDeclaration",
+		"aliasThisDeclaration",
+		"anonymousEnumDeclaration",
+		"attributeDeclaration",
+		"classDeclaration",
+		"conditionalDeclaration",
+		"constructor",
+		"debugSpecification",
+		"destructor",
+		"enumDeclaration",
+		"eponymousTemplateDeclaration",
+		"functionDeclaration",
+		"importDeclaration",
+		"interfaceDeclaration",
+		"invariant_",
+		"mixinDeclaration",
+		"mixinTemplateDeclaration",
+		"postblit",
+		"pragmaDeclaration",
+		"sharedStaticConstructor",
+		"sharedStaticDestructor",
+		"staticAssertDeclaration",
+		"staticConstructor",
+		"staticDestructor",
+		"structDeclaration",
+		"templateDeclaration",
+		"unionDeclaration",
+		"unittest_",
+		"variableDeclaration",
+		"versionSpecification",
+	);
+	if (decl.declarations !is null)
+		return true;
+
+	bool isNull;
+	foreach (property; properties)
+		if (mixin("decl." ~ property ~ " !is null"))
+			isNull = true;
+
+	return isNull;
+}

--- a/src/dscanner/analysis/config.d
+++ b/src/dscanner/analysis/config.d
@@ -197,6 +197,9 @@ struct StaticAnalysisConfig
 	@INI("Check for @trusted applied to a bigger scope than a single function")
 	string trust_too_much = Check.enabled;
 
+	@INI("Check for documented, but not public symbols")
+	string documented_non_public = Check.enabled;
+
 	@INI("Module-specific filters")
 	ModuleFilters filters;
 }

--- a/src/dscanner/analysis/documented_non_public.d
+++ b/src/dscanner/analysis/documented_non_public.d
@@ -1,0 +1,215 @@
+// Copyright (c) 2018, dlang-community
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+module dscanner.analysis.documented_non_public;
+
+import std.stdio;
+import std.string;
+import dparse.ast;
+import dparse.lexer;
+import dscanner.analysis.base;
+import dscanner.analysis.config : StaticAnalysisConfig, Check, disabledConfig;
+import dscanner.analysis.helpers;
+import dscanner.analysis.common;
+
+import dsymbol.scope_ : Scope;
+
+/**
+ * Checks for documented symbols that aren't public
+ */
+class DocumentedNonPublicCheck : BaseAnalyzer
+{
+	alias visit = BaseAnalyzer.visit;
+	enum string NON_PUBLIC_MESSAGE = "`%s` has a Ddoc documentation, but isn't public";
+
+	private bool isLastSeenVisibilityLabelPublic;
+
+	///
+	this(string fileName, bool skipTests = false)
+	{
+		super(fileName, null, skipTests);
+	}
+
+	override void visit(const Module mod)
+	{
+		isLastSeenVisibilityLabelPublic = true;
+		mod.accept(this);
+	}
+
+	override void visit(const Declaration decl)
+	{
+		import std.algorithm.searching : any;
+		import std.algorithm.iteration : map;
+
+		// skip private symbols
+		enum tokPrivate = tok!"private",
+			 tokProtected = tok!"protected",
+			 tokPackage = tok!"package",
+			 tokPublic = tok!"public";
+
+		if (decl.attributes.length > 0)
+		{
+			const bool isPublic = !decl.attributes.map!`a.attribute`.any!(x => x == tokPrivate ||
+																			   x == tokProtected ||
+																			   x == tokPackage);
+			// recognize label blocks
+			if (isLabel(decl))
+				isLastSeenVisibilityLabelPublic = isPublic;
+
+			if (!isPublic)
+				return;
+		}
+
+		if (isLastSeenVisibilityLabelPublic || decl.attributes.map!`a.attribute`.any!(x => x == tokPublic))
+		{
+			auto comment = hasComment(decl);
+			if (comment.hasComment)
+			{
+				string message = NON_PUBLIC_MESSAGE.format(comment.name);
+				addErrorMessage(comment.line, comment.column, "dscanner.analysis.documented_non_public", message);
+			}
+		}
+
+		decl.accept(this);
+	}
+
+	auto hasComment(const Declaration decl)
+	{
+		import std.meta : AliasSeq;
+		import std.typecons : Tuple;
+
+		Tuple!(size_t, "line", size_t, "column", string, "name", bool, "hasComment") result;
+
+		alias properties = AliasSeq!(
+			//"aliasDeclaration",
+		 	"classDeclaration",
+			 //"constructor",
+			 //"destructor",
+		 	"enumDeclaration",
+		 	"eponymousTemplateDeclaration",
+		 	"functionDeclaration",
+		 	"interfaceDeclaration",
+			 //"invariant_",
+			 //"sharedStaticConstructor",
+			 //"sharedStaticDestructor",
+			 //"staticConstructor",
+			 //"staticDestructor",
+		 	"structDeclaration",
+		 	"templateDeclaration",
+		 	"unionDeclaration",
+			 //"unittest_",
+		 	"variableDeclaration",
+		);
+		if (decl.declarations !is null)
+			return result;
+
+		static foreach (property; properties)
+		{{
+			mixin("auto d = decl." ~ property ~ ";");
+			if (d !is null && d.comment.ptr !is null) {
+				static if (__traits(compiles, d.name)) {
+					const t = d.name;
+				} else {
+					const t = d.declarators[0].name;
+				}
+				result.name = t.text;
+				result.line = t.line;
+				result.column = t.column;
+				result.hasComment = true;
+				return result;
+			}
+		}}
+
+		return result;
+	}
+}
+
+unittest
+{
+	StaticAnalysisConfig sac = disabledConfig();
+	sac.documented_non_public = Check.enabled;
+
+	// https://github.com/dlang-community/D-Scanner/issues/493
+	assertAnalyzerWarnings(q{
+///
+private int foo(){} // [warn]: %s
+
+///
+protected int foo(){} // [warn]: %s
+
+///
+package int foo(){} // [warn]: %s
+
+///
+int foo(){}
+
+///
+public int foo(){}
+	}c.format(
+		DocumentedNonPublicCheck.NON_PUBLIC_MESSAGE.format("foo"),
+		DocumentedNonPublicCheck.NON_PUBLIC_MESSAGE.format("foo"),
+		DocumentedNonPublicCheck.NON_PUBLIC_MESSAGE.format("foo"),
+	), sac);
+}
+
+unittest
+{
+	StaticAnalysisConfig sac = disabledConfig();
+	sac.documented_non_public = Check.enabled;
+
+	assertAnalyzerWarnings(q{
+protected:
+///
+int foo(){} // [warn]: %s
+private:
+///
+int foo(){} // [warn]: %s
+int bar(){}
+
+	}c.format(
+		DocumentedNonPublicCheck.NON_PUBLIC_MESSAGE.format("foo"),
+		DocumentedNonPublicCheck.NON_PUBLIC_MESSAGE.format("foo"),
+	), sac);
+
+	assertAnalyzerWarnings(q{
+protected {
+	///
+	int foo(){} // [warn]: %s
+
+}
+int bar(){}
+private {
+	///
+	int foo(){} // [warn]: %s
+}
+int bar(){}
+
+	}c.format(
+		DocumentedNonPublicCheck.NON_PUBLIC_MESSAGE.format("foo"),
+		DocumentedNonPublicCheck.NON_PUBLIC_MESSAGE.format("foo"),
+	), sac);
+
+	assertAnalyzerWarnings(q{
+
+struct Foo {
+	int bar(){}
+	protected {
+		///
+		int foo(){} // [warn]: %s
+	}
+	int bar(){}
+	private:
+	///
+	int foo(){} // [warn]: %s
+	public:
+	int bar(){}
+}
+	}c.format(
+		DocumentedNonPublicCheck.NON_PUBLIC_MESSAGE.format("foo"),
+		DocumentedNonPublicCheck.NON_PUBLIC_MESSAGE.format("foo"),
+	), sac);
+
+	stderr.writeln("Unittest for DocumentedNonPublicCheck passed.");
+}

--- a/src/dscanner/analysis/properly_documented_public_functions.d
+++ b/src/dscanner/analysis/properly_documented_public_functions.d
@@ -7,6 +7,7 @@ module dscanner.analysis.properly_documented_public_functions;
 import dparse.lexer;
 import dparse.ast;
 import dscanner.analysis.base : BaseAnalyzer;
+import dscanner.analysis.common;
 
 import std.format : format;
 import std.range.primitives;
@@ -63,7 +64,7 @@ class ProperlyDocumentedPublicFunctions : BaseAnalyzer
 																			   x == tokProtected ||
 																			   x == tokPackage);
 			// recognize label blocks
-			if (!hasDeclaration(decl))
+			if (isLabel(decl))
 				islastSeenVisibilityLabelPublic = isPublic;
 
 			if (!isPublic)
@@ -276,52 +277,6 @@ private:
 			return p.templateThisParameter.templateTypeParameter.identifier.text;
 
 		return null;
-	}
-
-	bool hasDeclaration(const Declaration decl)
-	{
-		import std.meta : AliasSeq;
-		alias properties = AliasSeq!(
-			"aliasDeclaration",
-			"aliasThisDeclaration",
-			"anonymousEnumDeclaration",
-			"attributeDeclaration",
-			"classDeclaration",
-			"conditionalDeclaration",
-			"constructor",
-			"debugSpecification",
-			"destructor",
-			"enumDeclaration",
-			"eponymousTemplateDeclaration",
-			"functionDeclaration",
-			"importDeclaration",
-			"interfaceDeclaration",
-			"invariant_",
-			"mixinDeclaration",
-			"mixinTemplateDeclaration",
-			"postblit",
-			"pragmaDeclaration",
-			"sharedStaticConstructor",
-			"sharedStaticDestructor",
-			"staticAssertDeclaration",
-			"staticConstructor",
-			"staticDestructor",
-			"structDeclaration",
-			"templateDeclaration",
-			"unionDeclaration",
-			"unittest_",
-			"variableDeclaration",
-			"versionSpecification",
-		);
-		if (decl.declarations !is null)
-			return false;
-
-		auto isNull = true;
-		foreach (property; properties)
-			if (mixin("decl." ~ property ~ " !is null"))
-				isNull = false;
-
-		return !isNull;
 	}
 }
 

--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -73,6 +73,7 @@ import dscanner.analysis.has_public_example;
 import dscanner.analysis.assert_without_msg;
 import dscanner.analysis.if_constraints_indent;
 import dscanner.analysis.trust_too_much;
+import dscanner.analysis.documented_non_public;
 
 import dsymbol.string_interning : internString;
 import dsymbol.scope_;
@@ -515,6 +516,10 @@ MessageSet analyze(string fileName, const Module m, const StaticAnalysisConfig a
 	if (moduleName.shouldRun!"trust_too_much"(analysisConfig))
 		checks ~= new TrustTooMuchCheck(fileName,
 		analysisConfig.trust_too_much == Check.skipTests && !ut);
+
+	if (moduleName.shouldRun!"documented_non_public"(analysisConfig))
+		checks ~= new DocumentedNonPublicCheck(fileName,
+		analysisConfig.documented_non_public == Check.skipTests && !ut);
 
 	version (none)
 		if (moduleName.shouldRun!"redundant_if_check"(analysisConfig))


### PR DESCRIPTION
Issue: https://github.com/dlang-community/D-Scanner/issues/493

Todo:

- [ ] check for visibility applied with labels (`public:`)
- [ ] check for visibility applied with blocks (`public{...}`))