### PR TITLE
Don't use the dscanner prefix for the ModuleFilter in the config INI

### DIFF
--- a/src/dscanner/analysis/config.d
+++ b/src/dscanner/analysis/config.d
@@ -213,7 +213,7 @@ private template ModuleFiltersMixin(A)
 	}();
 }
 
-@INI("ModuleFilters. +std.,-std.internal")
+@INI("ModuleFilters for selectively enabling (+std) and disabling (-std.internal) individual checks", "analysis.config.ModuleFilters")
 struct ModuleFilters
 {
 	mixin(ModuleFiltersMixin!int);


### PR DESCRIPTION
(we should probably tag 0.5.1 after this was merged)