### PR TITLE
Auto-deploy to DockerHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,24 @@ jobs:
           on:
             repo: dlang-community/D-Scanner
             tags: true
+    - stage: dockerhub-stable
+      if: tag IS present
+      d: ldc
+      os: linux
+      script:
+        - echo "Deploying to DockerHub..." && ./release.sh
+        - LATEST_TAG="$(git describe --abbrev=0 --tags)"
+        - docker build -t "dlangcommunity/dscanner:${LATEST_TAG} ."
+        - if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]] ; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" ; fi
+        - if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]] ; then docker push "dlangcommunity/dscanner:${LATEST_TAG}" ; fi
+    - stage: dockerhub-latest
+      d: ldc
+      os: linux
+      script:
+        - echo "Deploying to DockerHub..." && ./release.sh
+        - docker build -t dlangcommunity/dscanner:latest .
+        - if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]] ; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" ; fi
+        - if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]] ; then docker push dlangcommunity/dscanner:latest ; fi
 stages:
   - name: test
     if: type = pull_request or (type = push and branch = master)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM busybox
+
+MAINTAINER "DLang Community <community@dlang.io>"
+
+COPY bin/dscanner /dscanner
+RUN chmod +x /dscanner
+
+WORKDIR /src
+
+ENTRYPOINT [ "/dscanner" ]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# D-Scanner [![CI status](https://travis-ci.org/dlang-community/D-Scanner.svg?branch=master)](https://travis-ci.org/dlang-community/D-Scanner/)
+# D-Scanner
+
+[![CI status](https://travis-ci.org/dlang-community/D-Scanner.svg?branch=master)](https://travis-ci.org/dlang-community/D-Scanner/)
+[![Latest version](https://img.shields.io/dub/v/dscanner.svg)](http://code.dlang.org/packages/dscanner)
+[![License](https://img.shields.io/dub/l/dscanner.svg)](http://code.dlang.org/packages/dscanner)
+
 D-Scanner is a tool for analyzing D source code
 
 ### Building and installing
@@ -21,6 +26,14 @@ Under Windows run the tests with `build.bat test`.
 
 ```sh
 > dub fetch dscanner && dub run dscanner
+```
+
+## Installing with Docker
+
+With Docker no installation is required:
+
+```sh
+docker run --rm -v $(pwd):/src dlangcommunity/dscanner
 ```
 
 # Usage
@@ -52,6 +65,11 @@ to resolve the locations of the imported modules.
 
     $ dscanner --imports helloworld.d -I ~/.dvm/compilers/dmd-2.071.1-b2/src/phobos/ -I ~/.dvm/compilers/dmd-2.071.1-b2/src/druntime/src/
 	/home/brian/.dvm/compilers/dmd-2.071.1-b2/src/phobos/std/stdio.d
+
+Remember to pass map the import locations when you use Docker:
+
+	docker run --rm -v $(pwd):/src -v /usr/include/dlang/dmd:/d dlangcommunity/dscanner --imports helloworld.d -I/d
+	/d/std/stdio.d
 
 The "--recursiveImports" option is similar to "--imports", except that it lists
 imports of imports (and so on) recursively. The recursive import option requires


### PR DESCRIPTION
An attempt at https://github.com/dlang-community/D-Scanner/issues/591

Busybox requires a fully-static build, but that's cool. The compressed size is 2MB.
Even Alpine has ~5MB.

Play with this:

https://hub.docker.com/r/dlangcommunity/dscanner

While it ideally would be:

```
docker run --rm -v $(pwd):/src dlangcommunity/dscanner --styleCheck .
```

This still results in a lot of "Could not resolve/locate location of module" errors, hence this mapping is required:

```
docker run --rm -v $(pwd):/src -v /usr/include/dlang/dmd:/d dlangcommunity/dscanner --styleCheck . -I/d
```

(dscanner is agnostic about what standard library you use)

I added dlangcommunitybot account and gave it permissions to push to dlangcommunity/dscanner + added the tokens to the Travis environment flags.