### PR TITLE
Don't run the whole testsuite on special tag builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,3 +43,6 @@ jobs:
         on:
           repo: dlang-community/D-Scanner
           tags: true
+stages:
+  - name: test
+    if: type = pull_request or (type = push and branch = master)


### PR DESCRIPTION
Looking at the v0.5.1 build, it's pretty messy:

https://travis-ci.org/dlang-community/D-Scanner/builds/362549920

As this tag build is solely intended for deployment, we don't want random failures to mess up our release deployment.

![image](https://user-images.githubusercontent.com/4370550/38361419-8e7a0322-38cd-11e8-9be6-4396cdfc5679.png)
