### PR TITLE
Use git --describe tags as version string

### DIFF
--- a/makefile
+++ b/makefile
@@ -36,7 +36,7 @@ ldc: ldcbuild
 gdc: gdcbuild
 
 githash:
-	git log -1 --format="%H" > githash.txt
+	git describe --tags > githash.txt
 
 debug:
 	${DC} -w -g -J. -ofdsc ${VERSIONS} ${DEBUG_VERSIONS} ${INCLUDE_PATHS} ${SRC}

--- a/src/dscanner/dscanner_version.d
+++ b/src/dscanner/dscanner_version.d
@@ -8,19 +8,20 @@ module dscanner.dscanner_version;
 /**
  * Human-readable version number
  */
-enum DSCANNER_VERSION = "v0.4.0";
+enum DEFAUULT_DSCANNER_VERSION = "v0.5.0";
 
 version (built_with_dub)
 {
-	enum GIT_HASH = import("dubhash.txt");
+	enum DSCANNER_VERSION = import("dubhash.txt");
 }
 else version (Windows)
 {
+	enum DSCANNER_VERSION = DEFAUULT_DSCANNER_VERSION;
 }
 else
 {
 	/**
 	 * Current build's Git commit hash
 	 */
-	enum GIT_HASH = import("githash.txt");
+	enum DSCANNER_VERSION = import("githash.txt");
 }

--- a/src/dscanner/main.d
+++ b/src/dscanner/main.d
@@ -139,12 +139,7 @@ else
 
 	if (printVersion)
 	{
-		version (Windows)
-			writeln(DSCANNER_VERSION);
-		else version (built_with_dub)
-			writeln(DSCANNER_VERSION);
-		else
-			write(DSCANNER_VERSION, " ", GIT_HASH);
+		write(DSCANNER_VERSION);
 		return 0;
 	}
 


### PR DESCRIPTION
I just noticed that DScanner's version number doesn't get bumped and still pointed to 0.4.0 (rather confusing.)

As manually bumped the version is error-prone (i.e. it gets forgotten), I suggest to use `git describe --tags` wherever we can.

```
> ./bin/dscanner --version
v0.5.1-2-g3612c01
```

```
> git stash && git checkout v0.5.1 && git stash apply
> make
> ./bin/dscanner --version
v0.5.1-2-g3612c01
```