### PR TITLE
Generate a valid version for the DUB build

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -19,5 +19,9 @@
     "libddoc" : "~>0.3.0-beta.1",
     "stdx-allocator" : "~>2.77.0"
   },
-  "targetPath" : "bin"
+  "targetPath" : "bin",
+  "stringImportPaths": ["bin"],
+  "preGenerateCommands": [
+    "rdmd --eval='auto dir=environment.get(`DUB_PACKAGE_DIR`); dir.buildPath(`bin`).mkdirRecurse; auto gitVer = (`git -C `~dir~` describe --tags`).executeShell; (gitVer.status == 0 ? gitVer.output : dir.dirName.baseName.findSplitAfter(environment.get(`DUB_ROOT_PACKAGE`)~`-`)[1]).ifThrown(`0.0.0`).toFile(dir.buildPath(`bin`, `dubhash.txt`));'",
+  ]
 }

--- a/src/dscanner/dscanner_version.d
+++ b/src/dscanner/dscanner_version.d
@@ -10,10 +10,11 @@ module dscanner.dscanner_version;
  */
 enum DSCANNER_VERSION = "v0.4.0";
 
-version (Windows)
+version (built_with_dub)
 {
+	enum GIT_HASH = import("dubhash.txt");
 }
-else version (built_with_dub)
+else version (Windows)
 {
 }
 else


### PR DESCRIPTION
A hack at exposing the package's version for the DUB build.
It will default to `git describe --tags` (within the packages's directory) and if that fails it will detect its version based on the DUB package path.
If that fails too, it will fallback to `0.0.0`.

See also:

https://github.com/dlang-community/D-Scanner/pull/604 (which is about the outdated version)