### PR TITLE
fix #607 - Dscanner should warn about missing throws section in ddoc

### DIFF
--- a/src/dscanner/analysis/properly_documented_public_functions.d
+++ b/src/dscanner/analysis/properly_documented_public_functions.d
@@ -35,7 +35,7 @@ class ProperlyDocumentedPublicFunctions : BaseAnalyzer
 	enum string MISSING_RETURNS_MESSAGE = "A public function needs to contain a `Returns` section.";
 
 	enum string MISSING_THROW_KEY = "dscanner.style.doc_missing_throw";
-	enum string MISSING_THROW_MESSAGE = "An instance of `%s` is thrown but not documented in the `Throws` section'";
+	enum string MISSING_THROW_MESSAGE = "An instance of `%s` is thrown but not documented in the `Throws` section";
 
 	///
 	this(string fileName, bool skipTests = false)

--- a/src/dscanner/analysis/properly_documented_public_functions.d
+++ b/src/dscanner/analysis/properly_documented_public_functions.d
@@ -187,12 +187,17 @@ class ProperlyDocumentedPublicFunctions : BaseAnalyzer
 
 	override void visit(const ThrowStatement ts)
 	{
+		import std.algorithm.searching : canFind;
+
 		ts.accept(this);
 		if (ts.expression && ts.expression.items.length == 1)
 			if (const UnaryExpression ue = cast(UnaryExpression) ts.expression.items[0])
 		{
-			if (ue.newExpression && ue.newExpression.type)
+			if (ue.newExpression && ue.newExpression.type &&
+				!thrown.canFind!(a => a == ue.newExpression.type))
+			{
 				thrown ~= ue.newExpression.type;
+			}
 		}
 	}
 

--- a/src/dscanner/analysis/properly_documented_public_functions.d
+++ b/src/dscanner/analysis/properly_documented_public_functions.d
@@ -147,14 +147,14 @@ class ProperlyDocumentedPublicFunctions : BaseAnalyzer
 		// detect ThrowStatement only if not nothrow
 		if (!decl.attributes.any!(a => a.attribute.text == "nothrow"))
 		{
-		    decl.accept(this);
-		    if (nestedFuncs == 1 && !hasThrowSection(decl.comment))
-			    foreach(t; thrown)
-		    {
-			    Appender!(char[]) app;
-			    astFmt(&app, t);
-			    addErrorMessage(decl.name.line, decl.name.column, MISSING_THROW_KEY,
-				    MISSING_THROW_MESSAGE.format(app.data));
+			decl.accept(this);
+			if (nestedFuncs == 1 && !hasThrowSection(decl.comment))
+				foreach(t; thrown)
+			{
+				Appender!(char[]) app;
+				astFmt(&app, t);
+				addErrorMessage(decl.name.line, decl.name.column, MISSING_THROW_KEY,
+					MISSING_THROW_MESSAGE.format(app.data));
 			}
 		}
 
@@ -181,7 +181,7 @@ class ProperlyDocumentedPublicFunctions : BaseAnalyzer
 
 		if (ts.catches)
 			thrown =  thrown.filter!(a => !ts.catches.catches
-						   	.canFind!(b => b.type == a))
+							.canFind!(b => b.type == a))
 							.array;
 	}
 
@@ -192,7 +192,7 @@ class ProperlyDocumentedPublicFunctions : BaseAnalyzer
 			if (const UnaryExpression ue = cast(UnaryExpression) ts.expression.items[0])
 		{
 			if (ue.newExpression && ue.newExpression.type)
-		        thrown ~= ue.newExpression.type;
+				thrown ~= ue.newExpression.type;
 		}
 	}
 

--- a/src/dscanner/analysis/properly_documented_public_functions.d
+++ b/src/dscanner/analysis/properly_documented_public_functions.d
@@ -947,6 +947,22 @@ unittest
 
 	assertAnalyzerWarnings(q{
 /++
+Supposed to be documented
+
+Throws: Exception if...
++/
+void bar(){throw new Exception("bla");}
+	}c.format(
+	), sac);
+}
+
+unittest
+{
+	StaticAnalysisConfig sac = disabledConfig;
+	sac.properly_documented_public_functions = Check.enabled;
+
+	assertAnalyzerWarnings(q{
+/++
 rethrow
 +/
 void bar(){try throw new Exception("bla"); catch(Exception) throw new Error();} // [warn]: %s


### PR DESCRIPTION
Unfortunately the `Throws` section is not as formatted as The `Params` one and an accurate detection of what's documented as thrown would require parsing (with uncertain results). That's why the presence of the section is sufficient not to emit the warning, even if all the thrown Type are not all documented.