### PR TITLE
Change trust_too_much message which was slightly ambiguous

### DIFF
--- a/src/dscanner/analysis/trust_too_much.d
+++ b/src/dscanner/analysis/trust_too_much.d
@@ -19,7 +19,7 @@ class TrustTooMuchCheck : BaseAnalyzer
 private:
 
 	static immutable MESSAGE = "Trusting a whole scope is a bad idea, " ~
-		"`@trusted` should only be attached to a single function";
+		"`@trusted` should only be attached to single functions";
 	static immutable string KEY = "dscanner.trust_too_much";
 
 	bool checkAtAttribute = true;

--- a/src/dscanner/analysis/trust_too_much.d
+++ b/src/dscanner/analysis/trust_too_much.d
@@ -19,7 +19,7 @@ class TrustTooMuchCheck : BaseAnalyzer
 private:
 
 	static immutable MESSAGE = "Trusting a whole scope is a bad idea, " ~
-		"`@trusted` should only be attached individually to the functions";
+		"`@trusted` should only be attached to the functions individually";
 	static immutable string KEY = "dscanner.trust_too_much";
 
 	bool checkAtAttribute = true;

--- a/src/dscanner/analysis/trust_too_much.d
+++ b/src/dscanner/analysis/trust_too_much.d
@@ -19,7 +19,7 @@ class TrustTooMuchCheck : BaseAnalyzer
 private:
 
 	static immutable MESSAGE = "Trusting a whole scope is a bad idea, " ~
-		"`@trusted` should only be attached to single functions";
+		"`@trusted` should only be attached individually to the functions";
 	static immutable string KEY = "dscanner.trust_too_much";
 
 	bool checkAtAttribute = true;


### PR DESCRIPTION
It could be interpreted as "use it once in the whole scope"