### PR TITLE
Fix pre-generate command on Windows

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -24,6 +24,6 @@
     "bin"
   ],
   "preGenerateCommands" : [
-    "rdmd --eval='auto dir=environment.get(`DUB_PACKAGE_DIR`); dir.buildPath(`bin`).mkdirRecurse; auto gitVer = (`git -C `~dir~` describe --tags`).executeShell; (gitVer.status == 0 ? gitVer.output : dir.dirName.baseName.findSplitAfter(environment.get(`DUB_ROOT_PACKAGE`)~`-`)[1]).ifThrown(`0.0.0`).toFile(dir.buildPath(`bin`, `dubhash.txt`));'"
+    "rdmd --eval=\"auto dir=environment.get(\\\"DUB_PACKAGE_DIR\\\"); dir.buildPath(\\\"bin\\\").mkdirRecurse; auto gitVer = (\\\"git -C \\\"~dir~\\\" describe --tags\\\").executeShell; (gitVer.status == 0 ? gitVer.output : dir.dirName.baseName.findSplitAfter(environment.get(\\\"DUB_ROOT_PACKAGE\\\")~\\\"-\\\")[1]).ifThrown(\\\"0.0.0\\\").toFile(dir.buildPath(\\\"bin\\\", \\\"dubhash.txt\\\"));\""
   ]
 }


### PR DESCRIPTION
Using single quotes instead of double quotes seem to pose a problem on my Windows system for some reason... I end up with this when trying to compile it using dub:
```
object.Exception@rdmd.d(191): Cannot have both --eval and a program file ('dir=environment.get(`DUB_PACKAGE_DIR`);').
```