### PR TITLE
Remove dmd-beta and dmd-nightly from TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: d
 d:
-- dmd-nightly
-- dmd-beta
 - dmd
 - ldc-beta
 - ldc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,6 @@
 platform: x64
 environment:
  matrix:
-  #- DC: dmd
-    #DVersion: beta
-    #arch: x64
-  #- DC: dmd
-    #DVersion: beta
-    #arch: x86
   - DC: dmd
     DVersion: stable
     arch: x64


### PR DESCRIPTION
- dmd-nightly is tested by the D project tester.
- dmd-beta is not useful because most of the time it tests something that's already released.