### PR TITLE
Put the name of the variable which has a useless init between back ticks

### DIFF
--- a/src/dscanner/analysis/useless_initializer.d
+++ b/src/dscanner/analysis/useless_initializer.d
@@ -39,7 +39,7 @@ private:
 	}
 	else
 	{
-		enum msg = `Variable %s initializer is useless because it does not differ from the default value`;
+		enum msg = "Variable `%s` initializer is useless because it does not differ from the default value";
 	}
 
 	static immutable intDefs = ["0", "0L", "0UL", "0uL", "0U", "0x0", "0b0"];


### PR DESCRIPTION
For example after checking a module i can see

    Variable called initializer is useless because it does not differ from the default value

`called` is the variable name but here we can think it's `initializer`. It's  better to output

    Variable `called` initializer is useless because it does not differ from the default value