### PR TITLE
Improve auto-versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,10 +29,6 @@ obj
 # debug build
 dsc
 
-# Git hash
-githash.txt
-githash_.txt
-
 # GDB history
 .gdb_history
 

--- a/build.bat
+++ b/build.bat
@@ -6,17 +6,18 @@ if "%DC%"=="ldc2" set DC="ldmd2"
 
 :: git might not be installed, so we provide 0.0.0 as a fallback or use
 :: the existing githash file if existent
-git describe --tags > githash_.txt
-for /f %%i in ("githash_.txt") do set githashsize=%%~zi
+if not exist "bin" mkdir bin
+git describe --tags > bin\githash_.txt
+for /f %%i in ("bin\githash_.txt") do set githashsize=%%~zi
 if %githashsize% == 0 (
-	if not exist "githash.txt" (
-		echo v0.0.0 > githash.txt
+	if not exist "bin\githash.txt" (
+		echo v0.0.0 > bin\githash.txt
 	)
 ) else (
-	move /y githash_.txt githash.txt
+	move /y bin\githash_.txt bin\githash.txt
 )
 
-set DFLAGS=-O -release -inline -version=StdLoggerDisableWarning -J.
+set DFLAGS=-O -release -inline -version=StdLoggerDisableWarning -Jbin
 set TESTFLAGS=-g -w -version=StdLoggerDisableWarning
 set CORE=
 set LIBDPARSE=

--- a/release-windows.sh
+++ b/release-windows.sh
@@ -19,7 +19,7 @@ fi
 archiveName="dscanner-$VERSION-$OS-$ARCH_SUFFIX.zip"
 echo "Building $archiveName"
 mkdir -p bin
-git describe --tags > githash.txt # no git installed under Wine
+git describe --tags > bin/githash.txt # no git installed under Wine
 DC="$DIR/dmd2/windows/bin/dmd.exe" wine cmd /C build.bat
 
 cd bin

--- a/src/dscanner/dscanner_version.d
+++ b/src/dscanner/dscanner_version.d
@@ -5,18 +5,20 @@
 
 module dscanner.dscanner_version;
 
+import std.string : strip;
+
 /**
  * Human-readable version number
  */
 
 version (built_with_dub)
 {
-	enum DSCANNER_VERSION = import("dubhash.txt");
+	enum DSCANNER_VERSION = import("dubhash.txt").strip;
 }
 else
 {
 	/**
 	 * Current build's Git commit hash
 	 */
-	enum DSCANNER_VERSION = import("githash.txt");
+	enum DSCANNER_VERSION = import("githash.txt").strip;
 }


### PR DESCRIPTION
- put the `githash.txt` into `bin` on Windows too
- use `strip` to remove newlines from the version file