### PR TITLE
fix #685 - Useless final attribute detects false positives

### DIFF
--- a/src/dscanner/analysis/final_attribute.d
+++ b/src/dscanner/analysis/final_attribute.d
@@ -149,12 +149,14 @@ public:
 			undoBlockStatic = true;
 		}
 
+		const bool wasFinalAggr = _finalAggregate;
 		scope(exit)
 		{
 			d.accept(this);
 			_parent = savedParent;
 			if (undoBlockStatic)
 				_blockStatic = false;
+			_finalAggregate = wasFinalAggr;
 		}
 
 		if (!d.attributeDeclaration &&
@@ -401,6 +403,15 @@ public:
 	}c.format(
 		FinalAttributeChecker.MSGB.format(FinalAttributeChecker.MESSAGE.class_s)
 	), sac);
+
+
+	assertAnalyzerWarnings(q{
+		class Statement
+		{
+			final class UsesEH{}
+			final void comeFrom(){}
+		}
+	}, sac);
 
 	stderr.writeln("Unittest for FinalAttributeChecker passed.");
 }


### PR DESCRIPTION
The state of final aggregates was not restored after visiting a class.
The state of final aggregates didn't supported nesting.