### PR TITLE
Disable useless init chek by default

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -84,7 +84,7 @@ final_attribute_check="enabled"
 ; Check for virtual calls in the class constructors
 vcall_in_ctor="enabled"
 ; Check for useless user defined initializers
-useless_initializer="enabled"
+useless_initializer="disabled"
 ; Check allman brace style
 allman_braces_check="disabled"
 ; Check for redundant attributes


### PR DESCRIPTION
This one is more for consistency because people sometimes mix the two styles. More advanced D programmers may enable this check because they know the language better.