### PR TITLE
fix #696 - Unused variable fake positive with UFCS

### DIFF
--- a/src/dscanner/analysis/unused.d
+++ b/src/dscanner/analysis/unused.d
@@ -199,11 +199,10 @@ final class UnusedVariableCheck : BaseAnalyzer
 
 	override void visit(const UnaryExpression unary)
 	{
-		if (unary.prefix == tok!"*")
-			interestDepth++;
+		const bool interesting = unary.prefix == tok!"*" || unary.unaryExpression !is null;
+		interestDepth += interesting;
 		unary.accept(this);
-		if (unary.prefix == tok!"*")
-			interestDepth--;
+		interestDepth -= interesting;
 	}
 
 	override void visit(const MixinExpression mix)
@@ -537,6 +536,12 @@ private:
 	bool hasDittos(int decl)
 	{
 		mixin("decl++;");
+	}
+
+	void main()
+	{
+	    const int testValue;
+	    testValue.writeln;
 	}
 
 	}c, sac);


### PR DESCRIPTION
Apparently it was a bug not only specific to the UFCS.
Now every use of the member access operator is handled.