### PR TITLE
Update dsymbol

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -13,7 +13,7 @@
   ],
   "dependencies" : {
     "libdparse": "~>0.9.8",
-    "dsymbol" : "~>0.4.7",
+    "dsymbol" : "~>0.4.8",
     "inifiled" : "~>1.3.1",
     "emsi_containers" : "~>0.8.0-alpha.7",
     "libddoc" : "~>0.4.0",


### PR DESCRIPTION
Something, despite of working fine, was not done correctly previously so this update is just a matter a safety although no problems had been exprerienced, maybe due to the fact that it's not been officialy released. (it was the fix for #697)