### PR TITLE
Update dparse to get latest feature and fix for phobos linting

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -12,7 +12,7 @@
     "StdLoggerDisableWarning"
   ],
   "dependencies" : {
-    "libdparse": "~>0.10.8",
+    "libdparse": "~>0.10.10",
     "dsymbol" : "~>0.5.3",
     "inifiled" : "~>1.3.1",
     "emsi_containers" : "~>0.8.0-alpha.7",


### PR DESCRIPTION
This fixes problems with __vector, empty asm statement and __traits used as type (i'm a bit speculative with this one ... )