### PR TITLE
fix #762 - False positive on "unused variable" with side effect

### DIFF
--- a/src/dscanner/analysis/unused.d
+++ b/src/dscanner/analysis/unused.d
@@ -166,14 +166,9 @@ final class UnusedVariableCheck : BaseAnalyzer
 
 	override void visit(const AssignExpression assignExp)
 	{
-		if (assignExp.ternaryExpression !is null)
-			assignExp.ternaryExpression.accept(this);
-		if (assignExp.expression !is null)
-		{
-			interestDepth++;
-			assignExp.expression.accept(this);
-			interestDepth--;
-		}
+		interestDepth++;
+		assignExp.accept(this);
+		interestDepth--;
 	}
 
 	override void visit(const TemplateDeclaration templateDeclaration)
@@ -541,6 +536,13 @@ private:
 		cb1(3);
 		auto cb2 = delegate(size_t a) {}; // [warn]: Parameter a is never used.
 		cb2(3);
+	}
+
+	void oops ()
+	{
+	    class Identity { int val; }
+	    Identity v;
+	    v.val = 0;
 	}
 	
 	bool hasDittos(int decl)


### PR DESCRIPTION
So the problem was a probable confusion between the members of an `AssignExpression`. In the test case, the unary `v.val` is not represented by `assignExpression.expression` but by `assignExpression.ternaryExpression`, which, in the test case, is an `UnaryExpression`. The consequence was that the `interestDepth` counter was not incremented.