### PR TITLE
Document --errorFormat

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,13 @@ Limitations:
 ### Syntax Check
 The "--syntaxCheck" or "-s" option prints a listing of any errors or warnings found
 while lexing or parsing the given source file. It does not do any semantic
-analysis and it does not compile the code.
+analysis and it does not compile the code. The format of the errors or
+warnings can be configured with the "--errorFormat" or "-f" option.
 
 ### Style Check
 The "--styleCheck" or "-S" option runs some basic static analysis checks against
 the given source files, the sources contained in the given folders, or the sources contained in the current working directory (when nothing is supplied).
+The format of the errors or warnings can be configured with the "--errorFormat" or "-f" option.
 
 #### Skip style checks in the tests
 Static checks in the unit tests can produce irrelevant warnings. For example,

--- a/src/dscanner/main.d
+++ b/src/dscanner/main.d
@@ -341,15 +341,22 @@ Options:
         Similar to "--imports", but lists imports of imports recursively.
 
     --syntaxCheck <file>, -s <file>
-        Lexes and parses sourceFile, printing the line and column number of any
-        syntax errors to stdout. One error or warning is printed per line.
-        If no files are specified, input is read from stdin. %1$s will exit with
-        a status code of zero if no errors are found, 1 otherwise.
+        Lexes and parses sourceFile, printing the line and column number of
+        any syntax errors to stdout. One error or warning is printed per line,
+        and formatted according to the pattern passed to "--errorFormat".
+        If no files are specified, input is read from stdin. %1$s will exit
+        with a status code of zero if no errors are found, 1 otherwise.
 
     --styleCheck|S <file | directory>..., <file | directory>...
-        Lexes and parses sourceFiles, printing the line and column number of any
-        static analysis check failures stdout. %1$s will exit with a status code
-        of zero if no warnings or errors are found, 1 otherwise.
+        Lexes and parses sourceFiles, printing the line and column number of
+        any static analysis check failures stdout. One error or warning is
+        printed per line, and formatted according to the pattern passed to
+        "--errorFormat". %1$s will exit with a status code of zero if no
+        warnings or errors are found, 1 otherwise.
+
+    --errorFormat|f <pattern>
+        Format errors produced by the style/syntax checkers. The default
+        value for the pattern is: "%2$s".
 
     --ctags <file | directory>..., -c <file | directory>...
         Generates ctags information from the given source code file. Note that
@@ -389,7 +396,7 @@ Options:
     --skipTests
         Does not analyze in the unittests. Only works if --styleCheck.`,
 
-    programName);
+    programName, defaultErrorFormat);
 }
 
 private void doNothing(string, size_t, size_t, string, bool)


### PR DESCRIPTION
Hi,

The `--errorFormat` feature was not documented in #567, this PR addresses that problem.

HTH.