### PR TITLE
Track check name for error messages

### DIFF
--- a/src/dscanner/analysis/alias_syntax_check.d
+++ b/src/dscanner/analysis/alias_syntax_check.d
@@ -16,6 +16,8 @@ final class AliasSyntaxCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"alias_syntax_check";
+
 	this(string fileName, bool skipTests = false)
 	{
 		super(fileName, null, skipTests);

--- a/src/dscanner/analysis/allman.d
+++ b/src/dscanner/analysis/allman.d
@@ -6,7 +6,7 @@ module dscanner.analysis.allman;
 
 import dparse.lexer;
 import dparse.ast;
-import dscanner.analysis.base : BaseAnalyzer;
+import dscanner.analysis.base;
 import dsymbol.scope_ : Scope;
 
 import std.algorithm;
@@ -27,6 +27,8 @@ if (param < 0)
 */
 final class AllManCheck : BaseAnalyzer
 {
+	mixin AnalyzerInfo!"allman_braces_check";
+
 	///
 	this(string fileName, const(Token)[] tokens, bool skipTests = false)
 	{

--- a/src/dscanner/analysis/asm_style.d
+++ b/src/dscanner/analysis/asm_style.d
@@ -20,6 +20,8 @@ final class AsmStyleCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"asm_style_check";
+
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{
 		super(fileName, sc, skipTests);

--- a/src/dscanner/analysis/assert_without_msg.d
+++ b/src/dscanner/analysis/assert_without_msg.d
@@ -4,7 +4,7 @@
 
 module dscanner.analysis.assert_without_msg;
 
-import dscanner.analysis.base : BaseAnalyzer;
+import dscanner.analysis.base;
 import dscanner.utils : safeAccess;
 import dsymbol.scope_ : Scope;
 import dparse.lexer;
@@ -20,6 +20,7 @@ final class AssertWithoutMessageCheck : BaseAnalyzer
 {
 	enum string KEY = "dscanner.style.assert_without_msg";
 	enum string MESSAGE = "An assert should have an explanatory message";
+	mixin AnalyzerInfo!"assert_without_msg";
 
 	///
 	this(string fileName, const(Scope)* sc, bool skipTests = false)

--- a/src/dscanner/analysis/auto_function.d
+++ b/src/dscanner/analysis/auto_function.d
@@ -36,6 +36,8 @@ public:
 
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"auto_function_check";
+
 	///
 	this(string fileName, bool skipTests = false)
 	{

--- a/src/dscanner/analysis/auto_ref_assignment.d
+++ b/src/dscanner/analysis/auto_ref_assignment.d
@@ -14,6 +14,8 @@ import dscanner.analysis.base;
  */
 final class AutoRefAssignmentCheck : BaseAnalyzer
 {
+	mixin AnalyzerInfo!"auto_ref_assignment_check";
+
 	///
 	this(string fileName, bool skipTests = false)
 	{

--- a/src/dscanner/analysis/base.d
+++ b/src/dscanner/analysis/base.d
@@ -49,7 +49,7 @@ public:
 
 	protected string getName()
 	{
-		return null;
+		assert(0);
 	}
 
 	Message[] messages()

--- a/src/dscanner/analysis/base.d
+++ b/src/dscanner/analysis/base.d
@@ -18,11 +18,23 @@ struct Message
 	string key;
 	/// Warning message
 	string message;
+	/// Check name
+	string checkName;
 }
 
 enum comparitor = q{ a.line < b.line || (a.line == b.line && a.column < b.column) };
 
 alias MessageSet = RedBlackTree!(Message, comparitor, true);
+
+mixin template AnalyzerInfo(string checkName)
+{
+	enum string name = checkName;
+
+	override protected string getName()
+	{
+		return name;
+	}
+}
 
 abstract class BaseAnalyzer : ASTVisitor
 {
@@ -33,6 +45,11 @@ public:
 		this.fileName = fileName;
 		this.skipTests = skipTests;
 		_messages = new MessageSet;
+	}
+
+	protected string getName()
+	{
+		return null;
 	}
 
 	Message[] messages()
@@ -71,7 +88,7 @@ protected:
 
 	void addErrorMessage(size_t line, size_t column, string key, string message)
 	{
-		_messages.insert(Message(fileName, line, column, key, message));
+		_messages.insert(Message(fileName, line, column, key, message, getName()));
 	}
 
 	/**

--- a/src/dscanner/analysis/builtin_property_names.d
+++ b/src/dscanner/analysis/builtin_property_names.d
@@ -31,6 +31,8 @@ final class BuiltinPropertyNameCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"builtin_property_names_check";
+
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{
 		super(fileName, sc, skipTests);

--- a/src/dscanner/analysis/comma_expression.d
+++ b/src/dscanner/analysis/comma_expression.d
@@ -17,6 +17,8 @@ final class CommaExpressionCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"comma_expression_check";
+
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{
 		super(fileName, sc, skipTests);

--- a/src/dscanner/analysis/constructors.d
+++ b/src/dscanner/analysis/constructors.d
@@ -11,6 +11,8 @@ final class ConstructorCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"constructor_check";
+
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{
 		super(fileName, sc, skipTests);

--- a/src/dscanner/analysis/del.d
+++ b/src/dscanner/analysis/del.d
@@ -18,6 +18,8 @@ final class DeleteCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"delete_check";
+
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{
 		super(fileName, sc, skipTests);

--- a/src/dscanner/analysis/duplicate_attribute.d
+++ b/src/dscanner/analysis/duplicate_attribute.d
@@ -21,6 +21,8 @@ final class DuplicateAttributeCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"duplicate_attribute";
+
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{
 		super(fileName, sc, skipTests);

--- a/src/dscanner/analysis/enumarrayliteral.d
+++ b/src/dscanner/analysis/enumarrayliteral.d
@@ -19,6 +19,8 @@ final class EnumArrayLiteralCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"enum_array_literal_check";
+
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{
 		super(fileName, sc, skipTests);

--- a/src/dscanner/analysis/explicitly_annotated_unittests.d
+++ b/src/dscanner/analysis/explicitly_annotated_unittests.d
@@ -6,7 +6,7 @@ module dscanner.analysis.explicitly_annotated_unittests;
 
 import dparse.lexer;
 import dparse.ast;
-import dscanner.analysis.base : BaseAnalyzer;
+import dscanner.analysis.base;
 
 import std.stdio;
 
@@ -17,6 +17,7 @@ final class ExplicitlyAnnotatedUnittestCheck : BaseAnalyzer
 {
 	enum string KEY = "dscanner.style.explicitly_annotated_unittest";
 	enum string MESSAGE = "A unittest should be annotated with at least @safe or @system";
+    mixin AnalyzerInfo!"explicitly_annotated_unittests";
 
 	///
 	this(string fileName, bool skipTests = false)

--- a/src/dscanner/analysis/final_attribute.d
+++ b/src/dscanner/analysis/final_attribute.d
@@ -66,6 +66,8 @@ public:
 
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"final_attribute_check";
+
 	enum pushPopPrivate = q{
 		const bool wasPrivate = _private;
 		_private = false;

--- a/src/dscanner/analysis/fish.d
+++ b/src/dscanner/analysis/fish.d
@@ -20,6 +20,7 @@ final class FloatOperatorCheck : BaseAnalyzer
 	alias visit = BaseAnalyzer.visit;
 
 	enum string KEY = "dscanner.deprecated.floating_point_operators";
+	mixin AnalyzerInfo!"float_operator_check";
 
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{

--- a/src/dscanner/analysis/function_attributes.d
+++ b/src/dscanner/analysis/function_attributes.d
@@ -25,6 +25,8 @@ final class FunctionAttributeCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"function_attribute_check";
+
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{
 		super(fileName, sc, skipTests);

--- a/src/dscanner/analysis/has_public_example.d
+++ b/src/dscanner/analysis/has_public_example.d
@@ -20,6 +20,8 @@ final class HasPublicExampleCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"has_public_example";
+
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{
 		super(fileName, sc, skipTests);

--- a/src/dscanner/analysis/if_constraints_indent.d
+++ b/src/dscanner/analysis/if_constraints_indent.d
@@ -6,7 +6,7 @@ module dscanner.analysis.if_constraints_indent;
 
 import dparse.lexer;
 import dparse.ast;
-import dscanner.analysis.base : BaseAnalyzer, Message;
+import dscanner.analysis.base;
 import dsymbol.scope_ : Scope;
 
 import std.algorithm.iteration : filter;
@@ -17,6 +17,8 @@ Checks whether all if constraints have the same indention as their declaration.
 */
 final class IfConstraintsIndentCheck : BaseAnalyzer
 {
+	mixin AnalyzerInfo!"if_constraints_indent";
+
 	///
 	this(string fileName, const(Token)[] tokens, bool skipTests = false)
 	{

--- a/src/dscanner/analysis/if_statements.d
+++ b/src/dscanner/analysis/if_statements.d
@@ -13,6 +13,8 @@ import dsymbol.scope_ : Scope;
 final class IfStatementCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
+	mixin AnalyzerInfo!"redundant_if_check";
+
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{
 		super(fileName, sc, skipTests);

--- a/src/dscanner/analysis/ifelsesame.d
+++ b/src/dscanner/analysis/ifelsesame.d
@@ -24,6 +24,8 @@ final class IfElseSameCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"if_else_same_check";
+
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{
 		super(fileName, sc, skipTests);

--- a/src/dscanner/analysis/imports_sortedness.d
+++ b/src/dscanner/analysis/imports_sortedness.d
@@ -4,7 +4,7 @@
 
 module dscanner.analysis.imports_sortedness;
 
-import dscanner.analysis.base : BaseAnalyzer;
+import dscanner.analysis.base;
 import dparse.lexer;
 import dparse.ast;
 
@@ -17,6 +17,7 @@ final class ImportSortednessCheck : BaseAnalyzer
 {
 	enum string KEY = "dscanner.style.imports_sortedness";
 	enum string MESSAGE = "The imports are not sorted in alphabetical order";
+	mixin AnalyzerInfo!"imports_sortedness";
 
 	///
 	this(string fileName, bool skipTests = false)

--- a/src/dscanner/analysis/incorrect_infinite_range.d
+++ b/src/dscanner/analysis/incorrect_infinite_range.d
@@ -17,6 +17,8 @@ final class IncorrectInfiniteRangeCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"incorrect_infinite_range_check";
+
 	///
 	this(string fileName, bool skipTests = false)
 	{

--- a/src/dscanner/analysis/label_var_same_name_check.d
+++ b/src/dscanner/analysis/label_var_same_name_check.d
@@ -15,6 +15,8 @@ import dscanner.analysis.helpers;
  */
 final class LabelVarNameCheck : BaseAnalyzer
 {
+	mixin AnalyzerInfo!"label_var_same_name_check";
+
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{
 		super(fileName, sc, skipTests);

--- a/src/dscanner/analysis/lambda_return_check.d
+++ b/src/dscanner/analysis/lambda_return_check.d
@@ -14,6 +14,8 @@ final class LambdaReturnCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"lambda_return_check";
+
 	this(string fileName, bool skipTests = false)
 	{
 		super(fileName, null, skipTests);

--- a/src/dscanner/analysis/length_subtraction.d
+++ b/src/dscanner/analysis/length_subtraction.d
@@ -20,6 +20,8 @@ final class LengthSubtractionCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"length_subtraction_check";
+
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{
 		super(fileName, sc, skipTests);

--- a/src/dscanner/analysis/line_length.d
+++ b/src/dscanner/analysis/line_length.d
@@ -5,7 +5,7 @@
 
 module dscanner.analysis.line_length;
 
-import dscanner.analysis.base : BaseAnalyzer;
+import dscanner.analysis.base;
 
 import dparse.ast;
 import dparse.lexer;
@@ -17,6 +17,8 @@ import std.typecons : tuple, Tuple;
  */
 final class LineLengthCheck : BaseAnalyzer
 {
+	mixin AnalyzerInfo!"long_line_check";
+
 	///
 	this(string fileName, const(Token)[] tokens, bool skipTests = false)
 	{

--- a/src/dscanner/analysis/local_imports.d
+++ b/src/dscanner/analysis/local_imports.d
@@ -20,6 +20,8 @@ final class LocalImportCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"local_import_check";
+
 	/**
 	 * Construct with the given file name.
 	 */

--- a/src/dscanner/analysis/logic_precedence.d
+++ b/src/dscanner/analysis/logic_precedence.d
@@ -24,6 +24,7 @@ final class LogicPrecedenceCheck : BaseAnalyzer
 	alias visit = BaseAnalyzer.visit;
 
 	enum string KEY = "dscanner.confusing.logical_precedence";
+	mixin AnalyzerInfo!"logical_precedence_check";
 
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{

--- a/src/dscanner/analysis/mismatched_args.d
+++ b/src/dscanner/analysis/mismatched_args.d
@@ -1,6 +1,6 @@
 module dscanner.analysis.mismatched_args;
 
-import dscanner.analysis.base : BaseAnalyzer;
+import dscanner.analysis.base;
 import dscanner.utils : safeAccess;
 import dsymbol.scope_;
 import dsymbol.symbol;
@@ -11,6 +11,8 @@ import dsymbol.builtin.names;
 /// Checks for mismatched argument and parameter names
 final class MismatchedArgumentCheck : BaseAnalyzer
 {
+	mixin AnalyzerInfo!"mismatched_args_check";
+
 	///
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{

--- a/src/dscanner/analysis/numbers.d
+++ b/src/dscanner/analysis/numbers.d
@@ -21,6 +21,8 @@ final class NumberStyleCheck : BaseAnalyzer
 public:
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"number_style_check";
+
 	/**
 	 * Constructs the style checker with the given file name.
 	 */

--- a/src/dscanner/analysis/objectconst.d
+++ b/src/dscanner/analysis/objectconst.d
@@ -21,6 +21,8 @@ final class ObjectConstCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"object_const_check";
+
 	///
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{

--- a/src/dscanner/analysis/opequals_without_tohash.d
+++ b/src/dscanner/analysis/opequals_without_tohash.d
@@ -20,6 +20,8 @@ final class OpEqualsWithoutToHashCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"opequals_tohash_check";
+
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{
 		super(fileName, sc, skipTests);

--- a/src/dscanner/analysis/pokemon.d
+++ b/src/dscanner/analysis/pokemon.d
@@ -27,6 +27,7 @@ final class PokemonExceptionCheck : BaseAnalyzer
 {
 	enum MESSAGE = "Catching Error or Throwable is almost always a bad idea.";
 	enum string KEY = "dscanner.suspicious.catch_em_all";
+	mixin AnalyzerInfo!"exception_check";
 
 	alias visit = BaseAnalyzer.visit;
 

--- a/src/dscanner/analysis/properly_documented_public_functions.d
+++ b/src/dscanner/analysis/properly_documented_public_functions.d
@@ -7,7 +7,7 @@ module dscanner.analysis.properly_documented_public_functions;
 import dparse.lexer;
 import dparse.ast;
 import dparse.formatter : astFmt = format;
-import dscanner.analysis.base : BaseAnalyzer;
+import dscanner.analysis.base;
 import dscanner.utils : safeAccess;
 
 import std.format : format;
@@ -37,6 +37,8 @@ final class ProperlyDocumentedPublicFunctions : BaseAnalyzer
 
 	enum string MISSING_THROW_KEY = "dscanner.style.doc_missing_throw";
 	enum string MISSING_THROW_MESSAGE = "An instance of `%s` is thrown but not documented in the `Throws` section";
+
+	mixin AnalyzerInfo!"properly_documented_public_functions";
 
 	///
 	this(string fileName, bool skipTests = false)

--- a/src/dscanner/analysis/range.d
+++ b/src/dscanner/analysis/range.d
@@ -20,6 +20,8 @@ final class BackwardsRangeCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"backwards_range_check";
+
 	/// Key for this check in the report output
 	enum string KEY = "dscanner.bugs.backwards_slices";
 

--- a/src/dscanner/analysis/redundant_attributes.d
+++ b/src/dscanner/analysis/redundant_attributes.d
@@ -19,6 +19,8 @@ import std.range : empty, front, walkLength;
  */
 final class RedundantAttributesCheck : BaseAnalyzer
 {
+	mixin AnalyzerInfo!"redundant_attributes_check";
+
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{
 		super(fileName, sc, skipTests);

--- a/src/dscanner/analysis/redundant_parens.d
+++ b/src/dscanner/analysis/redundant_parens.d
@@ -17,6 +17,8 @@ final class RedundantParenCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"redundant_parens_check";
+
 	///
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{

--- a/src/dscanner/analysis/redundant_storage_class.d
+++ b/src/dscanner/analysis/redundant_storage_class.d
@@ -20,6 +20,7 @@ final class RedundantStorageClassCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 	enum string REDUNDANT_VARIABLE_ATTRIBUTES = "Variable declaration for `%s` has redundant attributes (%-(`%s`%|, %)).";
+	mixin AnalyzerInfo!"redundant_storage_classes";
 
 	this(string fileName, bool skipTests = false)
 	{

--- a/src/dscanner/analysis/static_if_else.d
+++ b/src/dscanner/analysis/static_if_else.d
@@ -26,6 +26,8 @@ final class StaticIfElse : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"static_if_else_check";
+
 	this(string fileName, bool skipTests = false)
 	{
 		super(fileName, null, skipTests);

--- a/src/dscanner/analysis/style.d
+++ b/src/dscanner/analysis/style.d
@@ -24,6 +24,7 @@ final class StyleChecker : BaseAnalyzer
 	enum string aggregateNameRegex = `^\p{Lu}[\w\d]*$`;
 	enum string moduleNameRegex = `^[\p{Ll}_\d]+$`;
 	enum string KEY = "dscanner.style.phobos_naming_convention";
+	mixin AnalyzerInfo!"style_check";
 
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{

--- a/src/dscanner/analysis/trust_too_much.d
+++ b/src/dscanner/analysis/trust_too_much.d
@@ -28,6 +28,8 @@ public:
 
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"trust_too_much";
+
 	///
 	this(string fileName, bool skipTests = false)
 	{

--- a/src/dscanner/analysis/undocumented.d
+++ b/src/dscanner/analysis/undocumented.d
@@ -21,6 +21,8 @@ final class UndocumentedDeclarationCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"undocumented_declaration_check";
+
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{
 		super(fileName, sc, skipTests);

--- a/src/dscanner/analysis/unmodified.d
+++ b/src/dscanner/analysis/unmodified.d
@@ -18,6 +18,8 @@ final class UnmodifiedFinder : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"could_be_immutable_check";
+
 	///
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{

--- a/src/dscanner/analysis/unused_label.d
+++ b/src/dscanner/analysis/unused_label.d
@@ -18,6 +18,8 @@ final class UnusedLabelCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"unused_label_check";
+
 	///
 	this(string fileName, const(Scope)* sc, bool skipTests = false)
 	{

--- a/src/dscanner/analysis/unused_parameter.d
+++ b/src/dscanner/analysis/unused_parameter.d
@@ -6,6 +6,7 @@ module dscanner.analysis.unused_parameter;
 
 import dparse.ast;
 import dparse.lexer;
+import dscanner.analysis.base;
 import dscanner.analysis.unused;
 import dsymbol.scope_ : Scope;
 
@@ -15,6 +16,8 @@ import dsymbol.scope_ : Scope;
 final class UnusedParameterCheck : UnusedIdentifierCheck
 {
 	alias visit = UnusedIdentifierCheck.visit;
+
+	mixin AnalyzerInfo!"unused_parameter_check";
 
 	/**
 	 * Params:

--- a/src/dscanner/analysis/unused_variable.d
+++ b/src/dscanner/analysis/unused_variable.d
@@ -5,6 +5,7 @@
 module dscanner.analysis.unused_variable;
 
 import dparse.ast;
+import dscanner.analysis.base;
 import dscanner.analysis.unused;
 import dsymbol.scope_ : Scope;
 import std.algorithm.iteration : map;
@@ -15,6 +16,8 @@ import std.algorithm.iteration : map;
 final class UnusedVariableCheck : UnusedIdentifierCheck
 {
 	alias visit = UnusedIdentifierCheck.visit;
+
+	mixin AnalyzerInfo!"unused_variable_check";
 
 	/**
 	 * Params:

--- a/src/dscanner/analysis/useless_assert.d
+++ b/src/dscanner/analysis/useless_assert.d
@@ -27,6 +27,8 @@ final class UselessAssertCheck : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"useless_assert_check";
+
 	///
 	this(string fileName, bool skipTests = false)
 	{

--- a/src/dscanner/analysis/useless_initializer.d
+++ b/src/dscanner/analysis/useless_initializer.d
@@ -29,6 +29,8 @@ final class UselessInitializerChecker : BaseAnalyzer
 {
 	alias visit = BaseAnalyzer.visit;
 
+	mixin AnalyzerInfo!"useless_initializer";
+
 private:
 
 	enum key = "dscanner.useless-initializer";

--- a/src/dscanner/analysis/vcall_in_ctor.d
+++ b/src/dscanner/analysis/vcall_in_ctor.d
@@ -20,6 +20,8 @@ final class VcallCtorChecker : BaseAnalyzer
 {
     alias visit = BaseAnalyzer.visit;
 
+    mixin AnalyzerInfo!"vcall_in_ctor";
+
 private:
 
     enum string KEY = "dscanner.vcall_ctor";


### PR DESCRIPTION
This PR adds `name` key to the `--report` output which contains check name (as specified in the configuration) as suggested here: https://github.com/dlang-community/D-Scanner/issues/613.

Also makes introducing further options, like error codes (https://github.com/dlang-community/D-Scanner/issues/687) easier (would require less changes to the code).