### PR TITLE
Support checkName in errorFormat

### DIFF
--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -105,6 +105,7 @@ void messageFunctionFormat(string format, Message message, bool isError)
 	s = s.replace("{column}", to!string(message.column));
 	s = s.replace("{type}", isError ? "error" : "warn");
 	s = s.replace("{message}", message.message);
+    s = s.replace("{name}", message.checkName);
 
 	writefln("%s", s);
 }

--- a/src/dscanner/main.d
+++ b/src/dscanner/main.d
@@ -376,6 +376,8 @@ Options:
     --errorFormat|f <pattern>
         Format errors produced by the style/syntax checkers. The default
         value for the pattern is: "%2$s".
+        Supported placeholders are: {filepath}, {line}, {column}, {type},
+        {message}, and {name}.
 
     --ctags <file | directory>..., -c <file | directory>...
         Generates ctags information from the given source code file. Note that
@@ -395,7 +397,7 @@ Options:
         tree. If no files are specified, input is read from stdin.
 
     --declaration <symbolName> <file | directory>...,
-	-d <symbolName> <file | directory>...
+    -d <symbolName> <file | directory>...
         Find the location where symbolName is declared. This should be more
         accurate than "grep". Searches the given files and directories, or the
         current working directory if none are specified.


### PR DESCRIPTION
Adds support for the check name in `--errorFormat` and updates the help message a bit.