### PR TITLE
Use bash from PATH

### DIFF
--- a/makefile
+++ b/makefile
@@ -32,7 +32,7 @@ override GDC_FLAGS += $(DFLAGS)
 DMD_TEST_FLAGS = -w -g -Jbin -version=StdLoggerDisableWarning
 override LDC_FLAGS += -O5 -release -oq -d-version=StdLoggerDisableWarning
 override GDC_FLAGS += -O3 -frelease -d-version=StdLoggerDisableWarning
-SHELL:=/bin/bash
+SHELL:=/usr/bin/env bash
 
 all: dmdbuild
 ldc: ldcbuild


### PR DESCRIPTION
I use NixOS which supports multiple versions of bash by storing each one in its own unique directory.  The version is selected through symbolic links and the PATH variable.  This means using the `/usr/bin/env` mechanism to invoke programs rather than hardcoded absolute paths to programs like `/bin/bash`. This mechanism should be backwards compatible with existing distributions and also accommodates newer environments like Nix which can simultaneously support any number of versions of any program.