### PR TITLE
Fix empty error messages in issue 786

### DIFF
--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -265,7 +265,7 @@ const(Module) parseModule(string fileName, ubyte[] code, RollbackAllocator* p,
 		ulong* linesOfCode = null, uint* errorCount = null, uint* warningCount = null)
 {
 	auto writeMessages = delegate(string fileName, size_t line, size_t column, string message, bool isError){
-		return messageFunctionFormat(errorFormat, Message(fileName, line, column, message), isError);
+		return messageFunctionFormat(errorFormat, Message(fileName, line, column, "dscanner.syntax", message), isError);
 	};
 
 	return parseModule(fileName, code, p, cache, tokens,


### PR DESCRIPTION
The message was assigned to Message.key and hence not printed.

Note that this does _not_ fix the issue itself, just the hidden messages.