### PR TITLE
Fix compilation error for unittests on windows

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -19,7 +19,7 @@ if %githashsize% == 0 (
 )
 
 set DFLAGS=-O -release -version=StdLoggerDisableWarning -Jbin %MFLAGS%
-set TESTFLAGS=-g -w -version=StdLoggerDisableWarning
+set TESTFLAGS=-g -w -version=StdLoggerDisableWarning -Jbin
 set CORE=
 set LIBDPARSE=
 set STD=


### PR DESCRIPTION
`build.bat test` failed because the explicit string import path (`-Jbin`) was missing.