### PR TITLE
[wip] ignore warnings with @suppress(key) comments

### DIFF
--- a/src/dscanner/analysis/base.d
+++ b/src/dscanner/analysis/base.d
@@ -88,6 +88,17 @@ protected:
 
 	void addErrorMessage(size_t line, size_t column, string key, string message)
 	{
+        import std.file : readText;
+        import std.array : split;
+        import std.ascii : newline;
+        import std.algorithm : canFind;
+
+        string l = readText(fileName).split(newline)[line-1];
+        if (l.canFind("@suppress(" ~ key ~ ")"))
+        {
+            return;
+        }
+
 		_messages.insert(Message(fileName, line, column, key, message, getName()));
 	}
 


### PR DESCRIPTION
very much work in progress, its very inefficient and error prone, but its a good working concept.

you can ignore warnings on specific lines by adding a suppressing comment to the end of the line, example:

```d
void main()
{
    import std.stdio : writeln;

    int a = 5; // @suppress(dscanner.suspicious.unmodified)

    writeln(a);
}
```

some issues with my implementation:
* whether the suppress message is in a comment isn't checked
* for every warning im reading the file and finding the line of the warning, ideally this would be done once per file only