### PR TITLE
Exclude `.git` from search paths.

### DIFF
--- a/src/dscanner/utils.d
+++ b/src/dscanner/utils.d
@@ -84,7 +84,7 @@ string[] expandArgs(string[] args)
 {
 	import std.file : isFile, FileException, dirEntries, SpanMode;
 	import std.algorithm.iteration : map;
-	import std.algorithm.searching : endsWith;
+	import std.algorithm.searching : endsWith, find;
 
 	// isFile can throw if it's a broken symlink.
 	bool isFileSafe(T)(T a)
@@ -105,7 +105,7 @@ string[] expandArgs(string[] args)
 		else
 			foreach (item; dirEntries(arg, SpanMode.breadth).map!(a => a.name))
 			{
-				if (isFileSafe(item) && (item.endsWith(`.d`) || item.endsWith(`.di`)))
+				if (isFileSafe(item) && (item.endsWith(`.d`) || item.endsWith(`.di`)) && !item.find('.git'))
 					rVal ~= item;
 				else
 					continue;

--- a/src/dscanner/utils.d
+++ b/src/dscanner/utils.d
@@ -4,7 +4,6 @@ import std.array : appender, uninitializedArray;
 import std.stdio : stdin, stderr, File;
 import std.conv : to;
 import std.encoding : BOM, BOMSeq, EncodingException, getBOM;
-import std.path : dirSeparator;
 import std.format : format;
 import std.file : exists, read;
 
@@ -85,7 +84,8 @@ string[] expandArgs(string[] args)
 {
 	import std.file : isFile, FileException, dirEntries, SpanMode;
 	import std.algorithm.iteration : map;
-	import std.algorithm.searching : endsWith, find;
+	import std.algorithm.searching : endsWith, canFind;
+	import std.path : dirSeparator;
 
 	// isFile can throw if it's a broken symlink.
 	bool isFileSafe(T)(T a)

--- a/src/dscanner/utils.d
+++ b/src/dscanner/utils.d
@@ -4,6 +4,7 @@ import std.array : appender, uninitializedArray;
 import std.stdio : stdin, stderr, File;
 import std.conv : to;
 import std.encoding : BOM, BOMSeq, EncodingException, getBOM;
+import std.path : dirSeparator;
 import std.format : format;
 import std.file : exists, read;
 
@@ -105,7 +106,7 @@ string[] expandArgs(string[] args)
 		else
 			foreach (item; dirEntries(arg, SpanMode.breadth).map!(a => a.name))
 			{
-				if (isFileSafe(item) && (item.endsWith(`.d`) || item.endsWith(`.di`)) && !item.find('.git'))
+				if (isFileSafe(item) && (item.endsWith(`.d`) || item.endsWith(`.di`)) && !item.find(dirSeparator ~ '.'))
 					rVal ~= item;
 				else
 					continue;

--- a/src/dscanner/utils.d
+++ b/src/dscanner/utils.d
@@ -106,7 +106,7 @@ string[] expandArgs(string[] args)
 		else
 			foreach (item; dirEntries(arg, SpanMode.breadth).map!(a => a.name))
 			{
-				if (isFileSafe(item) && (item.endsWith(`.d`) || item.endsWith(`.di`)) && !item.find(dirSeparator ~ '.'))
+				if (isFileSafe(item) && (item.endsWith(`.d`) || item.endsWith(`.di`)) && !item.canFind(dirSeparator ~ '.'))
 					rVal ~= item;
 				else
 					continue;


### PR DESCRIPTION
Currently dscanner searches for files in the target directory ending in `.d` or `.di`.

EDIT: This PR at first referred to just the `.git` directory. I've since widened the scope to cover all hidden directories. 

Git has some hidden files in `.git`, which log commits to files. These files share the same name as the tracked file: For example `.git/logs/refs/heads/somedfile.d` actually contains Git data, not D code.

A naive call to dscanner using `dscanner --syntaxCheck .` or `dscanner --styleCheck .` (therefore also `dub lint...`), inside a D project whichs is also a Git repository, will attempt to check these Git files. The result is spurious errors, such as:

```sh
./.git/logs/refs/heads/yourfile.d(1:1)[error]:
./.git/logs/refs/heads/yourfile.d(1:118)[warn]: Line is longer than 120 characters
```

I believe Git is a common enough tool that we're justified to handle this case inside D scanner, rather than asking the user to write configuration files with dodge the `.git` folder.

Alternatively we could add an `--ignore $PATH` command line argument to filter out paths eaisly. 