### PR TITLE
change license in dub.json to match dub format

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -5,7 +5,7 @@
   "authors" : [
     "Brian Schott"
   ],
-  "license" : "Boost Software License - Version 1.0",
+  "license" : "BSL-1.0",
   "targetType" : "autodetect",
   "versions" : [
     "built_with_dub",


### PR DESCRIPTION
changes the license string to use a standard license identifier as described in https://dub.pm/package-format-json.html#licenses