### PR TITLE
Use const instead of immutable for compatibility with new libdparse

### DIFF
--- a/src/dscanner/analysis/auto_function.d
+++ b/src/dscanner/analysis/auto_function.d
@@ -78,7 +78,7 @@ public:
 			if (!p)
 				return;
 
-			immutable token = p.primary;
+			const token = p.primary;
 			if (token.type == tok!"false")
 				_returns[$-1] = true;
 			else if (token.text == "0")

--- a/src/dscanner/analysis/mismatched_args.d
+++ b/src/dscanner/analysis/mismatched_args.d
@@ -133,7 +133,7 @@ final class ArgVisitor : ASTVisitor
 		{
 			if (iot.identifier == tok!"")
 				return;
-			immutable t = iot.identifier;
+			const t = iot.identifier;
 			lines ~= t.line;
 			columns ~= t.column;
 			args ~= internString(t.text);

--- a/src/dscanner/analysis/useless_assert.d
+++ b/src/dscanner/analysis/useless_assert.d
@@ -44,7 +44,7 @@ final class UselessAssertCheck : BaseAnalyzer
 			return;
 		if (unary.primaryExpression is null)
 			return;
-		immutable token = unary.primaryExpression.primary;
+		const token = unary.primaryExpression.primary;
 		immutable skipSwitch = unary.primaryExpression.arrayLiteral !is null
 			|| unary.primaryExpression.assocArrayLiteral !is null
 			|| unary.primaryExpression.functionLiteralExpression !is null;


### PR DESCRIPTION
Looks like the libdparse token changes weren't as backwards-compatible as we hoped. See https://github.com/dlang-community/D-Scanner/pull/799#issuecomment-617104293