### PR TITLE
check libdparse & dsymbol with min/max dub version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "stdx-allocator"]
 	path = stdx-allocator
 	url = https://github.com/dlang-community/stdx-allocator.git
+[submodule "d-test-utils"]
+	path = d-test-utils
+	url = https://github.com/dlang-community/d-test-utils.git

--- a/.travis.sh
+++ b/.travis.sh
@@ -3,7 +3,14 @@
 set -e
 
 if [[ $BUILD == dub ]]; then
-    dub test
+    if [[ -n $LIBDPARSE_VERSION ]]; then
+        rdmd ./d-test-utils/test_with_package.d $LIBDPARSE_VERSION libdparse -- dub test
+    elif if [[ -n $DSYMBOL_VERSION ]]; then
+        rdmd ./d-test-utils/test_with_package.d $DSYMBOL_VERSION dsymbol -- dub test
+    else
+        echo 'Cannot run test without LIBDPARSE_VERSION nor DSYMBOL_VERSION environment variable'
+        exit 1
+    fi
 elif [[ $DC == ldc2 ]]; then
     git submodule update --init --recursive
     make test DC=ldmd2

--- a/.travis.sh
+++ b/.travis.sh
@@ -5,7 +5,7 @@ set -e
 if [[ $BUILD == dub ]]; then
     if [[ -n $LIBDPARSE_VERSION ]]; then
         rdmd ./d-test-utils/test_with_package.d $LIBDPARSE_VERSION libdparse -- dub test
-    elif if [[ -n $DSYMBOL_VERSION ]]; then
+    elif [[ -n $DSYMBOL_VERSION ]]; then
         rdmd ./d-test-utils/test_with_package.d $DSYMBOL_VERSION dsymbol -- dub test
     else
         echo 'Cannot run test without LIBDPARSE_VERSION nor DSYMBOL_VERSION environment variable'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ os:
 - osx
 env:
 - BUILD=
-- BUILD=dub
+- BUILD=dub LIBDPARSE_VERSION=min
+- BUILD=dub LIBDPARSE_VERSION=max
+- BUILD=dub DSYMBOL_VERSION=min
+- BUILD=dub DSYMBOL_VERSION=max
 branches:
   only:
   - master


### PR DESCRIPTION
analogous to https://github.com/dlang-community/dfmt/pull/491 this will run the dub tests first with minimum libdparse version, then with maximum libdparse version, then with minimum dsymbol version and with maximum dsymbol version.

This makes version ranges of dependencies easier to test.