### PR TITLE
Disable the local imports check by default

### DIFF
--- a/src/dscanner/analysis/config.d
+++ b/src/dscanner/analysis/config.d
@@ -123,7 +123,7 @@ struct StaticAnalysisConfig
 	string comma_expression_check = Check.enabled;
 
 	@INI("Checks for local imports that are too broad")
-	string local_import_check = Check.enabled;
+	string local_import_check = Check.disabled;
 
 	@INI("Checks for variables that could be declared immutable")
 	string could_be_immutable_check = Check.enabled;

--- a/src/dscanner/analysis/config.d
+++ b/src/dscanner/analysis/config.d
@@ -122,7 +122,7 @@ struct StaticAnalysisConfig
 	@INI("Checks for use of the comma operator")
 	string comma_expression_check = Check.enabled;
 
-	@INI("Checks for local imports that are too broad")
+	@INI("Checks for local imports that are too broad. Only accurate when checking code used with D versions older than 2.071.0")
 	string local_import_check = Check.disabled;
 
 	@INI("Checks for variables that could be declared immutable")


### PR DESCRIPTION
As discussed in #808, this just disables the check by default. It can be enabled by people who (for some reason) need to use an older version of the compiler.