### PR TITLE
Configurable max line length

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -57,8 +57,10 @@ redundant_parens_check="enabled"
 mismatched_args_check="enabled"
 ; Checks for labels with the same name as variables
 label_var_same_name_check="enabled"
-; Checks for lines longer than 120 characters
+; Checks for lines longer than `max_line_length` characters
 long_line_check="disabled"
+; Maximum line length in `long_line_check`.
+max_line_length="120"
 ; Checks for assignment to auto-ref function parameters
 auto_ref_assignment_check="enabled"
 ; Checks for incorrect infinite range definitions

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Note that the "--skipTests" option is the equivalent of changing each
 * Variables that could have been declared const or immutable (experimental)
 * Redundant parenthesis.
 * Unused labels.
-* Lines longer than 120 characters.
+* Lines longer than `max_line_length` characters.
 * Incorrect infinite range definitions.
 * Some assertions that check conditions that will always be true.
 * Auto functions without return statement. The compiler doesn't see an omission and it infers 'void' as return type.

--- a/src/dscanner/analysis/config.d
+++ b/src/dscanner/analysis/config.d
@@ -140,8 +140,11 @@ struct StaticAnalysisConfig
 	@INI("Checks for labels with the same name as variables")
 	string label_var_same_name_check = Check.enabled;
 
-	@INI("Checks for lines longer than 120 characters")
+	@INI("Checks for lines longer than `max_line_length` characters")
 	string long_line_check = Check.enabled;
+
+	@INI("The maximum line length used in `long_line_check`.")
+	int max_line_length = 120;
 
 	@INI("Checks for assignment to auto-ref function parameters")
 	string auto_ref_assignment_check = Check.enabled;

--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -502,6 +502,7 @@ MessageSet analyze(string fileName, const Module m, const StaticAnalysisConfig a
 
 	if (moduleName.shouldRun!LineLengthCheck(analysisConfig))
 		checks ~= new LineLengthCheck(fileName, tokens,
+		analysisConfig.max_line_length,
 		analysisConfig.long_line_check == Check.skipTests && !ut);
 
 	if (moduleName.shouldRun!AutoRefAssignmentCheck(analysisConfig))


### PR DESCRIPTION
I'd like to make `enum MAX_LINE_LENGTH = 120` configurable because dfmt has a similar option.

```bash
dfmt --inplace --space_after_cast=false --max_line_length=80 \
    --soft_max_line_length=70 --brace_style=otbs file.d
```
https://github.com/dlang-community/dfmt#example