### PR TITLE
Add Github Actions setup to replace Travis

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -1,0 +1,142 @@
+name: run-tests
+
+on:
+  pull_request:
+
+  push:
+    branches:
+      - master
+
+jobs:
+  main:
+    name: Run all tests
+
+    # Only run for the main repository - not forks
+    if: ${{ github.repository == 'dlang-community/D-Scanner' }}
+
+    # Run permutations of common os + host compilers
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [
+          {
+            version: dmd-latest,
+            dmd: dmd
+          },
+          {
+            version: ldc-latest,
+            dmd: ldmd2
+          },
+          {
+            # Install dmd for the associated tools (dub/rdmd)
+            version: dmd-latest,
+            dmd: gdmd
+          }
+        ]
+        host: [
+          ubuntu-latest,
+          macos-latest,
+          windows-latest
+        ]
+        build: [
+          { type: make },
+          { type: dub, version: 'min libdparse' },
+          # Fail due to unresolvable dependencies
+          # { type: dub, version: 'max libdparse' },
+          # { type: dub, version: 'min dsymbol' },
+          # { type: dub, version: 'max dsymbol' },
+        ]
+
+        exclude:
+          # Restrict GDC to Ubuntu
+          - compiler:
+              dmd: gdmd
+            host: windows-latest
+          - compiler:
+              dmd: gdmd
+            host: macos-latest
+
+          #  Omit dub builds for GDC because dub rejects the old fronted revision
+          - compiler:
+              dmd: gdmd
+            build:
+              type: dub
+
+    runs-on: ${{ matrix.host }}
+
+    steps:
+      # Clone repo + submodules
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+           submodules: 'recursive'
+           fetch-depth: 0
+
+      # Install the host compiler (DMD or LDC)
+      # Also grabs DMD for GDC to include dub + rdmd
+      - name: Install ${{ matrix.compiler.version }}
+        if: ${{ matrix.compiler.dmd != 'gdmd' || matrix.build.type == 'dub' }} # Fetch required tools for GDC
+        uses: dlang-community/setup-dlang@v1
+        with:
+          compiler: ${{ matrix.compiler.version }}
+
+        # GDC not yet supported by setup-dlang
+      - name: Install GDC via apt-get
+        if: ${{ matrix.compiler.dmd == 'gdmd' }}
+        run: |
+          sudo apt-get install gdc gdmd -y
+          gdc --version
+
+      # Compile D-Scanner and execute all tests without dub
+      - name: Build and test without dub
+        if: ${{ matrix.build.type == 'make' }}
+        env:
+          DC: ${{ matrix.compiler.dmd }}
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            export MFLAGS="-m64"
+            ./build.bat
+            ./build.bat test
+          else
+            make "-j$(nproc)" all test
+          fi
+
+      # Compile D-Scanner and execute all tests using a specific dependency version
+      # Currently skipped for GDC (dub installed from apt-get is broken)
+      - name: Build and test with dub
+        if: ${{ matrix.build.type == 'dub' }}
+        env:
+          DC: ${{ matrix.compiler.dmd }}
+        run: |
+          rdmd ./d-test-utils/test_with_package.d ${{ matrix.build.version }} -- dub build
+          rdmd ./d-test-utils/test_with_package.d ${{ matrix.build.version }} -- dub test
+
+      # Lint source code using the previously built binary
+      - name: Run linter
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            EXE=".exe"
+          else
+            EXE=""
+          fi
+          "./bin/dscanner$EXE" --config .dscanner.ini --styleCheck src
+
+      # Parse phobos to check for failures / crashes / ...
+      - name: Checkout Phobos
+        uses: actions/checkout@v2
+        with:
+          repository: dlang/phobos
+          path: phobos
+
+      - name: Apply D-Scanner to Phobos
+        if:  ${{ matrix.build.version != 'min libdparse'}} # Older versions crash with "Invalid UTF..."
+        working-directory: phobos
+        shell: bash
+        run: |
+          for FILE in $(find std -name '*.d');
+          do
+            echo "$FILE"
+            ../bin/dscanner -S --config=.dscanner.ini "$FILE"
+          done

--- a/build.bat
+++ b/build.bat
@@ -36,6 +36,7 @@ for %%x in (src\dscanner\analysis\*.d) do set ANALYSIS=!ANALYSIS! %%x
 for %%x in (libdparse\src\dparse\*.d) do set LIBDPARSE=!LIBDPARSE! %%x
 for %%x in (libdparse\src\std\experimental\*.d) do set LIBDPARSE=!LIBDPARSE! %%x
 for %%x in (libddoc\src\ddoc\*.d) do set LIBDDOC=!LIBDDOC! %%x
+for %%x in (libddoc\common\source\ddoc\*.d) do set LIBDDOC=!LIBDDOC! %%x
 for %%x in (inifiled\source\*.d) do set INIFILED=!INIFILED! %%x
 for %%x in (dsymbol\src\dsymbol\*.d) do set DSYMBOL=!DSYMBOL! %%x
 for %%x in (dsymbol\src\dsymbol\builtin\*.d) do set DSYMBOL=!DSYMBOL! %%x
@@ -48,14 +49,14 @@ for %%x in (stdx-allocator\source\stdx\allocator\building_blocks\*.d) do set STD
 if "%1" == "test" goto test_cmd
 
 @echo on
-%DC% %MFLAGS% %CORE% %STD% %LIBDPARSE% %LIBDDOC% %ANALYSIS% %INIFILED% %DSYMBOL% %CONTAINERS% %STDXALLOCATOR% %STDXALLOCATORBLOCKS% %DFLAGS% -I"libdparse\src" -I"dsymbol\src" -I"containers\src" -I"libddoc\src" -I"stdx-allocator\source" -ofbin\dscanner.exe
+%DC% %MFLAGS% %CORE% %STD% %LIBDPARSE% %LIBDDOC% %ANALYSIS% %INIFILED% %DSYMBOL% %CONTAINERS% %STDXALLOCATOR% %STDXALLOCATORBLOCKS% %DFLAGS% -I"libdparse\src" -I"dsymbol\src" -I"containers\src" -I"libddoc\src" -I"libddoc\common\source" -I"stdx-allocator\source" -ofbin\dscanner.exe
 goto eof
 
 :test_cmd
 @echo on
 set TESTNAME="bin\dscanner-unittest"
 %DC% %MFLAGS% %STD% %LIBDPARSE% %LIBDDOC% %INIFILED% %DSYMBOL% %CONTAINERS% %STDXALLOCATOR% %STDXALLOCATORBLOCKS% -I"libdparse\src" -I"dsymbol\src" -I"containers\src" -I"libddoc\src" -I"stdx-allocator\source" -lib %TESTFLAGS% -of%TESTNAME%.lib
-if exist %TESTNAME%.lib %DC% %MFLAGS% %CORE% %ANALYSIS% %TESTNAME%.lib -I"src" -I"inifiled\source" -I"libdparse\src" -I"dsymbol\src" -I"containers\src" -I"libddoc\src" -I"stdx-allocator\source" -unittest %TESTFLAGS% -of%TESTNAME%.exe
+if exist %TESTNAME%.lib %DC% %MFLAGS% %CORE% %ANALYSIS% %TESTNAME%.lib -I"src" -I"inifiled\source" -I"libdparse\src" -I"dsymbol\src" -I"containers\src" -I"libddoc\src" -I"libddoc\common\source" -I"stdx-allocator\source" -unittest %TESTFLAGS% -of%TESTNAME%.exe
 if exist %TESTNAME%.exe %TESTNAME%.exe
 
 if exist %TESTNAME%.obj del %TESTNAME%.obj


### PR DESCRIPTION
The configured workflow tests D-Scanner with different host compilers
(DMD / LDC / GDC) on different platforms ( Windows / OSX / Linux).

The tests include
- `build.bat test` (windows) or `make test`
- `dub test` for version ranges of `libdparse` and `dsymbol`
   (currently disabled because of unresolvable dependency constraints)
- `make lint`
- phobos linting

---

[Last run](https://github.com/MoonlightSentinel/D-Scanner/actions/runs/1753237054)