### PR TITLE
fix libdparse deprecation in new check

### DIFF
--- a/src/dscanner/analysis/cyclomatic_complexity.d
+++ b/src/dscanner/analysis/cyclomatic_complexity.d
@@ -70,7 +70,7 @@ final class CyclomaticComplexityCheck : BaseAnalyzer
 	mixin VisitComplex!AndAndExpression;
 	mixin VisitComplex!OrOrExpression;
 	mixin VisitComplex!TernaryExpression;
-	mixin VisitComplex!ThrowStatement;
+	mixin VisitComplex!ThrowExpression;
 	mixin VisitComplex!Catch;
 	mixin VisitComplex!LastCatch;
 	mixin VisitComplex!ReturnStatement;


### PR DESCRIPTION
Forgot to include this in the libdparse upgrade / it got merged before the new check addition and didn't adjust the new check.