### PR TITLE
upload bin folders as artifacts to test locally

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -112,6 +112,11 @@ jobs:
           rdmd ./d-test-utils/test_with_package.d ${{ matrix.build.version }} -- dub build
           rdmd ./d-test-utils/test_with_package.d ${{ matrix.build.version }} -- dub test
 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: bin-${{matrix.build.type}}-${{matrix.build.version}}-${{ matrix.compiler.dmd }}-${{ matrix.host }}
+          path: bin
+
       # Lint source code using the previously built binary
       - name: Run linter
         shell: bash


### PR DESCRIPTION
want this for #857 to validate that the --version actually returns the correct thing, but allows to test PR executables without building them yourself as well.

Feels like we are really milking GitHub's actions storage space with this. lol