### PR TITLE
downgrade dsymbol to 0.13.0

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -12,8 +12,8 @@
     "StdLoggerDisableWarning"
   ],
   "dependencies" : {
-    "libdparse": ">=0.19.2 <1.0.0",
-    "dsymbol" : ">=0.13.0 <1.0.0",
+    "libdparse": "0.19.2",
+    "dsymbol" : "0.13.0",
     "inifiled" : "~>1.3.1",
     "emsi_containers" : "~>0.8.0",
     "libddoc" : "~>0.8.0",


### PR DESCRIPTION
fixes introduced std.experimental.allocator issues:

- https://forum.dlang.org/post/ufizivohhdpsxyemifzr@forum.dlang.org
- https://github.com/dlang/dub/pull/2293#issuecomment-1176077114
- #871 