### PR TITLE
Update readme CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # D-Scanner
 
-[![CI status](https://travis-ci.org/dlang-community/D-Scanner.svg?branch=master)](https://travis-ci.org/dlang-community/D-Scanner/)
+[![CI status](https://github.com/dlang-community/D-Scanner/actions/workflows/default.yml/badge.svg)](https://github.com/dlang-community/D-Scanner/actions?query=workflow%3A%22run+tests%22)
 [![Latest version](https://img.shields.io/dub/v/dscanner.svg)](http://code.dlang.org/packages/dscanner)
 [![License](https://img.shields.io/dub/l/dscanner.svg)](http://code.dlang.org/packages/dscanner)
 


### PR DESCRIPTION
The current build badge shows a permanent failing status because the last travis build from two years ago failed, and travis appears to be no longer used. This PR switches the badge to show the status using github actions.