### PR TITLE
don't use deprecated properties

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -12,7 +12,7 @@
     "StdLoggerDisableWarning"
   ],
   "dependencies": {
-    "libdparse": ">=0.22.0 <0.23.0",
+    "libdparse": ">=0.21.0 <0.23.0",
     "dcd:dsymbol": ">=0.14.0 <0.16.0",
     "inifiled": "~>1.3.1",
     "emsi_containers": "~>0.9.0",

--- a/dub.json
+++ b/dub.json
@@ -12,7 +12,7 @@
     "StdLoggerDisableWarning"
   ],
   "dependencies": {
-    "libdparse": ">=0.21.0 <0.23.0",
+    "libdparse": ">=0.21.1 <0.23.0",
     "dcd:dsymbol": ">=0.14.0 <0.16.0",
     "inifiled": "~>1.3.1",
     "emsi_containers": "~>0.9.0",

--- a/dub.json
+++ b/dub.json
@@ -12,7 +12,7 @@
     "StdLoggerDisableWarning"
   ],
   "dependencies": {
-    "libdparse": ">=0.20.0 <0.23.0",
+    "libdparse": ">=0.22.0 <0.23.0",
     "dcd:dsymbol": ">=0.14.0 <0.16.0",
     "inifiled": "~>1.3.1",
     "emsi_containers": "~>0.9.0",

--- a/src/dscanner/analysis/if_statements.d
+++ b/src/dscanner/analysis/if_statements.d
@@ -28,14 +28,14 @@ final class IfStatementCheck : BaseAnalyzer
 
 		++depth;
 
-		if (ifStatement.expression.items.length == 1
-				&& (cast(AndAndExpression) ifStatement.expression.items[0]) is null)
+		if (ifStatement.condition.expression.items.length == 1
+				&& (cast(AndAndExpression) ifStatement.condition.expression.items[0]) is null)
 		{
-			redundancyCheck(ifStatement.expression,
-					ifStatement.expression.line, ifStatement.expression.column);
+			redundancyCheck(ifStatement.condition.expression,
+					ifStatement.condition.expression.line, ifStatement.condition.expression.column);
 		}
 		inIfExpresson = true;
-		ifStatement.expression.accept(this);
+		ifStatement.condition.expression.accept(this);
 		inIfExpresson = false;
 		ifStatement.thenStatement.accept(this);
 		if (expressions.length)

--- a/src/dscanner/analysis/redundant_parens.d
+++ b/src/dscanner/analysis/redundant_parens.d
@@ -28,9 +28,9 @@ final class RedundantParenCheck : BaseAnalyzer
 	override void visit(const IfStatement statement)
 	{
 		UnaryExpression unary;
-		if (statement.expression is null || statement.expression.items.length != 1)
+		if (statement.condition.expression is null || statement.condition.expression.items.length != 1)
 			goto end;
-		unary = cast(UnaryExpression) statement.expression.items[0];
+		unary = cast(UnaryExpression) statement.condition.expression.items[0];
 		if (unary is null)
 			goto end;
 		if (unary.primaryExpression is null)

--- a/src/dscanner/analysis/unused.d
+++ b/src/dscanner/analysis/unused.d
@@ -92,10 +92,10 @@ abstract class UnusedIdentifierCheck : BaseAnalyzer
 
 	override void visit(const WhileStatement whileStatement)
 	{
-		if (whileStatement.expression !is null)
+		if (whileStatement.condition.expression !is null)
 		{
 			interestDepth++;
-			whileStatement.expression.accept(this);
+			whileStatement.condition.expression.accept(this);
 			interestDepth--;
 		}
 		if (whileStatement.declarationOrStatement !is null)
@@ -136,10 +136,10 @@ abstract class UnusedIdentifierCheck : BaseAnalyzer
 
 	override void visit(const IfStatement ifStatement)
 	{
-		if (ifStatement.expression !is null)
+		if (ifStatement.condition.expression !is null)
 		{
 			interestDepth++;
-			ifStatement.expression.accept(this);
+			ifStatement.condition.expression.accept(this);
 			interestDepth--;
 		}
 		if (ifStatement.thenStatement !is null)

--- a/src/dscanner/astprinter.d
+++ b/src/dscanner/astprinter.d
@@ -460,15 +460,15 @@ class XMLPrinter : ASTVisitor
 		output.writeln("<ifStatement>");
 
 		output.writeln("<condition>");
-		if (ifStatement.identifier.type != tok!"")
+		if (ifStatement.condition.identifier.type != tok!"")
 		{
-			if (ifStatement.type is null)
+			if (ifStatement.condition.type is null)
 				output.writeln("<auto/>");
 			else
-				visit(ifStatement.type);
-			visit(ifStatement.identifier);
+				visit(ifStatement.condition.type);
+			visit(ifStatement.condition.identifier);
 		}
-		ifStatement.expression.accept(this);
+		ifStatement.condition.expression.accept(this);
 		output.writeln("</condition>");
 
 		output.writeln("<then>");


### PR DESCRIPTION
this silences some of the deprecation warnings emitted when building.