### PR TITLE
hide dsymbol warnings, fix #890

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -18,8 +18,8 @@ if %githashsize% == 0 (
 	move /y bin\githash_.txt bin\githash.txt
 )
 
-set DFLAGS=-O -release -version=StdLoggerDisableWarning -Jbin %MFLAGS%
-set TESTFLAGS=-g -w -version=StdLoggerDisableWarning -Jbin
+set DFLAGS=-O -release -Jbin %MFLAGS%
+set TESTFLAGS=-g -w -Jbin
 set CORE=
 set LIBDPARSE=
 set STD=

--- a/dub.json
+++ b/dub.json
@@ -8,8 +8,7 @@
   "license" : "BSL-1.0",
   "targetType" : "autodetect",
   "versions" : [
-    "built_with_dub",
-    "StdLoggerDisableWarning"
+    "built_with_dub"
   ],
   "dependencies": {
     "libdparse": ">=0.21.1 <0.23.0",

--- a/makefile
+++ b/makefile
@@ -44,11 +44,14 @@ INCLUDE_PATHS = \
 	-Ilibddoc/src \
 	-Ilibddoc/common/source
 
-DMD_VERSIONS = -version=StdLoggerDisableWarning
+# e.g. "-version=MyCustomVersion"
+DMD_VERSIONS =
 DMD_DEBUG_VERSIONS = -version=dparse_verbose
-LDC_VERSIONS = -d-version=StdLoggerDisableWarning
+# e.g. "-d-version=MyCustomVersion"
+LDC_VERSIONS =
 LDC_DEBUG_VERSIONS = -d-version=dparse_verbose
-GDC_VERSIONS = -fversion=StdLoggerDisableWarning
+# e.g. "-fversion=MyCustomVersion"
+GDC_VERSIONS =
 GDC_DEBUG_VERSIONS = -fversion=dparse_verbose
 
 DC_FLAGS += -Jbin

--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -610,3 +610,21 @@ MessageSet analyze(string fileName, const Module m, const StaticAnalysisConfig a
 
 	return set;
 }
+
+version (unittest)
+{
+	shared static this()
+	{
+		// mute dsymbol warnings in tests
+		static if (__VERSION__ >= 2_101_0)
+		{
+			import std.logger;
+			sharedLog.globalLogLevel = LogLevel.error;
+		}
+		else
+		{
+			import std.experimental.logger;
+			globalLogLevel = LogLevel.error;
+		}
+	}
+}

--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -618,12 +618,12 @@ version (unittest)
 		// mute dsymbol warnings in tests
 		static if (__VERSION__ >= 2_101_0)
 		{
-			import std.logger;
+			import std.logger : sharedLog, LogLevel;
 			sharedLog.globalLogLevel = LogLevel.error;
 		}
 		else
 		{
-			import std.experimental.logger;
+			import std.experimental.logger : globalLogLevel, LogLevel;
 			globalLogLevel = LogLevel.error;
 		}
 	}

--- a/src/dscanner/main.d
+++ b/src/dscanner/main.d
@@ -69,6 +69,7 @@ else
 	string[] importPaths;
 	bool printVersion;
 	bool explore;
+	bool verbose;
 	string errorFormat;
 
 	try
@@ -100,7 +101,9 @@ else
 				"muffinButton", &muffin,
 				"explore", &explore,
 				"skipTests", &skipTests,
-				"errorFormat|f", &errorFormat);
+				"errorFormat|f", &errorFormat,
+				"verbose|v", &verbose
+				);
 		//dfmt on
 	}
 	catch (ConvException e)
@@ -112,6 +115,21 @@ else
 	{
 		stderr.writeln(e.msg);
 		return 1;
+	}
+
+	{
+		static if (__VERSION__ >= 2_101_0)
+			import std.logger;
+		else
+			import std.experimental.logger;
+		// we don't use std.logger, but dsymbol does, so we surpress all
+		// messages that aren't errors from it by default
+		// users can use verbose to enable all logs (this will log things like
+		// dsymbol couldn't find some modules due to wrong import paths)
+		static if (__VERSION__ >= 2_101_0)
+			sharedLog.globalLogLevel = verbose ? LogLevel.all : LogLevel.error;
+		else
+			globalLogLevel = verbose ? LogLevel.all : LogLevel.error;
 	}
 
 	if (muffin)

--- a/src/dscanner/main.d
+++ b/src/dscanner/main.d
@@ -119,9 +119,9 @@ else
 
 	{
 		static if (__VERSION__ >= 2_101_0)
-			import std.logger;
+			import std.logger : sharedLog, LogLevel;
 		else
-			import std.experimental.logger;
+			import std.experimental.logger : globalLogLevel, LogLevel;
 		// we don't use std.logger, but dsymbol does, so we surpress all
 		// messages that aren't errors from it by default
 		// users can use verbose to enable all logs (this will log things like


### PR DESCRIPTION
Now missing imports and such can be shown with `--verbose` or `-v`