### PR TITLE
also add byte indices to diagnostic ranges

### DIFF
--- a/src/dscanner/analysis/auto_function.d
+++ b/src/dscanner/analysis/auto_function.d
@@ -75,7 +75,8 @@ public:
 				// highlight on the whitespace between attribute and function name
 				auto tok = autoTokens[$ - 1];
 				auto whitespace = tok.column + (tok.text.length ? tok.text.length : str(tok.type).length);
-				addErrorMessage(tok.line, whitespace, whitespace + 1, KEY, MESSAGE_INSERT);
+				auto whitespaceIndex = tok.index + (tok.text.length ? tok.text.length : str(tok.type).length);
+				addErrorMessage([whitespaceIndex, whitespaceIndex + 1], tok.line, [whitespace, whitespace + 1], KEY, MESSAGE_INSERT);
 			}
 			else
 				addErrorMessage(autoTokens, KEY, MESSAGE);

--- a/src/dscanner/analysis/if_constraints_indent.d
+++ b/src/dscanner/analysis/if_constraints_indent.d
@@ -33,12 +33,12 @@ final class IfConstraintsIndentCheck : BaseAnalyzer
 			// t.line (unsigned) may be 0 if the token is uninitialized/broken, so don't subtract from it
 			// equivalent to: firstSymbolAtLine.length < t.line - 1
 			while (firstSymbolAtLine.length + 1 < t.line)
-				firstSymbolAtLine ~= Pos(1);
+				firstSymbolAtLine ~= Pos(1, t.index);
 
 			// insert a new line with positions if new line is reached
 			// (previous while pads skipped lines)
 			if (firstSymbolAtLine.length < t.line)
-				firstSymbolAtLine ~= Pos(t.column, t.type == tok!"if");
+				firstSymbolAtLine ~= Pos(t.column, t.index, t.type == tok!"if");
 		}
 	}
 
@@ -96,6 +96,7 @@ private:
 	static struct Pos
 	{
 		size_t column;
+		size_t index;
 		bool isIf;
 	}
 
@@ -123,7 +124,7 @@ private:
 		if (r.empty)
 			addErrorMessage(if_, KEY, MESSAGE);
 		else if (pDecl.column != r.front.column)
-			addErrorMessage(if_.line, min(if_.column, pDecl.column), if_.column + 2, KEY, MESSAGE);
+			addErrorMessage([min(if_.index, pDecl.index), if_.index + 2], if_.line, [min(if_.column, pDecl.column), if_.column + 2], KEY, MESSAGE);
 	}
 }
 

--- a/src/dscanner/analysis/line_length.d
+++ b/src/dscanner/analysis/line_length.d
@@ -62,7 +62,7 @@ private:
 
 		if (tok.line != lastErrorLine)
 		{
-			addErrorMessage(tok.line, maxLineLength, max(maxLineLength + 1, tok.column + 1), KEY, message);
+			addErrorMessage([0, 0], tok.line, [maxLineLength, max(maxLineLength + 1, tok.column + 1)], KEY, message);
 			lastErrorLine = tok.line;
 		}
 	}

--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -157,8 +157,10 @@ void writeJSON(Message message)
 	writeln(`      "fileName": "`, message.fileName.replace("\\", "\\\\").replace(`"`, `\"`), `",`);
 	writeln(`      "line": `, message.startLine, `,`);
 	writeln(`      "column": `, message.startColumn, `,`);
+	writeln(`      "index": `, message.startIndex, `,`);
 	writeln(`      "endLine": `, message.endLine, `,`);
 	writeln(`      "endColumn": `, message.endColumn, `,`);
+	writeln(`      "endIndex": `, message.endIndex, `,`);
 	writeln(`      "message": "`, message.message.replace("\\", "\\\\").replace(`"`, `\"`), `",`);
 	if (message.supplemental.length)
 	{

--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -139,7 +139,7 @@ void messageFunction(Message message, bool isError)
 
 void messageFunctionJSON(string fileName, size_t line, size_t column, string message, bool)
 {
-	writeJSON(Message(Message.Diagnostic.from(fileName, line, column, column, message), "dscanner.syntax"));
+	writeJSON(Message(Message.Diagnostic.from(fileName, [0, 0], line, [column, column], message), "dscanner.syntax"));
 }
 
 void writeJSON(Message message)
@@ -199,8 +199,9 @@ void generateReport(string[] fileNames, const StaticAnalysisConfig config,
 	auto reporter = new DScannerJsonReporter();
 
 	auto writeMessages = delegate void(string fileName, size_t line, size_t column, string message, bool isError){
+		// TODO: proper index and column ranges
 		reporter.addMessage(
-			Message(Message.Diagnostic.from(fileName, line, column, column, message), "dscanner.syntax"),
+			Message(Message.Diagnostic.from(fileName, [0, 0], line, [column, column], message), "dscanner.syntax"),
 			isError);
 	};
 
@@ -239,8 +240,9 @@ void generateSonarQubeGenericIssueDataReport(string[] fileNames, const StaticAna
 	auto reporter = new SonarQubeGenericIssueDataReporter();
 
 	auto writeMessages = delegate void(string fileName, size_t line, size_t column, string message, bool isError){
+		// TODO: proper index and column ranges
 		reporter.addMessage(
-			Message(Message.Diagnostic.from(fileName, line, column, column, message), "dscanner.syntax"),
+			Message(Message.Diagnostic.from(fileName, [0, 0], line, [column, column], message), "dscanner.syntax"),
 			isError);
 	};
 
@@ -327,8 +329,9 @@ const(Module) parseModule(string fileName, ubyte[] code, RollbackAllocator* p,
 		ulong* linesOfCode = null, uint* errorCount = null, uint* warningCount = null)
 {
 	auto writeMessages = delegate(string fileName, size_t line, size_t column, string message, bool isError){
+		// TODO: proper index and column ranges
 		return messageFunctionFormat(errorFormat,
-			Message(Message.Diagnostic.from(fileName, line, column, column, message), "dscanner.syntax"),
+			Message(Message.Diagnostic.from(fileName, [0, 0], line, [column, column], message), "dscanner.syntax"),
 			isError);
 	};
 

--- a/src/dscanner/reports.d
+++ b/src/dscanner/reports.d
@@ -61,8 +61,10 @@ class DScannerJsonReporter
 			"fileName": JSONValue(issue.message.fileName),
 			"line": JSONValue(issue.message.startLine),
 			"column": JSONValue(issue.message.startColumn),
+			"index": JSONValue(issue.message.startIndex),
 			"endLine": JSONValue(issue.message.endLine),
 			"endColumn": JSONValue(issue.message.endColumn),
+			"endIndex": JSONValue(issue.message.endIndex),
 			"message": JSONValue(issue.message.message),
 			"type": JSONValue(issue.type),
 			"supplemental": JSONValue(
@@ -71,8 +73,10 @@ class DScannerJsonReporter
 						"fileName": JSONValue(a.fileName),
 						"line": JSONValue(a.startLine),
 						"column": JSONValue(a.startColumn),
+						"index": JSONValue(a.startIndex),
 						"endLine": JSONValue(a.endLine),
 						"endColumn": JSONValue(a.endColumn),
+						"endIndex": JSONValue(a.endIndex),
 						"message": JSONValue(a.message),
 					])
 				).array


### PR DESCRIPTION
For tools wanting to read from the source file this makes it much easier to look up the code.

Before we tag the new API with start and end locations as new tag, we better just add this together with everything, since then we don't need to change the API again later. Grouping together lines / columns as size_t[2] also makes the previous API better to understand, e.g. because of `size_t line, size_t startColumn, size_t endColumn` now being `size_t line, size_t[2] columns`