### PR TITLE
add auto-fix API

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,32 @@ dscanner lint source/
 
 to view a human readable list of issues.
 
+Diagnostic types can be enabled/disabled using a configuration file, check out
+the `--config` argument / `dscanner.ini` file for more info. Tip: some IDEs that
+integrate D-Scanner may have helpers to configure the diagnostics or help
+generate the dscanner.ini file.
+<!--
+IDE list for overview:
+code-d has an "insert default dscanner.ini content" command + proprietary
+	disabling per-line (we really need to bring that into standard D-Scanner)
+-->
+
+## Auto-Fixing issues
+
+Use
+
+```sh
+dscanner fix source/
+```
+
+to interactively fix all fixable issues within the source directory. Call with
+`--applySingle` to automatically apply fixes that don't have multiple automatic
+solutions.
+
+## Tooling integration
+
+Many D editors already ship with D-Scanner.
+
 For a CLI / tool parsable output use either
 
 ```sh
@@ -74,16 +100,6 @@ dscanner -S -f github source/
 # custom format:
 dscanner -S -f '{filepath}({line}:{column})[{type}]: {message}' source/
 ```
-
-Diagnostic types can be enabled/disabled using a configuration file, check out
-the `--config` argument / `dscanner.ini` file for more info. Tip: some IDEs that
-integrate D-Scanner may have helpers to configure the diagnostics or help
-generate the dscanner.ini file.
-<!--
-IDE list for overview:
-code-d has an "insert default dscanner.ini content" command + proprietary
-	disabling per-line (we really need to bring that into standard D-Scanner)
--->
 
 ## Other features
 

--- a/src/dscanner/analysis/auto_function.d
+++ b/src/dscanner/analysis/auto_function.d
@@ -270,5 +270,16 @@ unittest
 		auto doStuff(){ mixin(_genSave);}
 	}, sac);
 
+
+	assertAutoFix(q{
+		auto doStuff(){} // fix
+		@property doStuff(){} // fix
+		@safe doStuff(){} // fix
+	}c, q{
+		void doStuff(){} // fix
+		@property void doStuff(){} // fix
+		@safe void doStuff(){} // fix
+	}c, sac);
+
 	stderr.writeln("Unittest for AutoFunctionChecker passed.");
 }

--- a/src/dscanner/analysis/auto_function.d
+++ b/src/dscanner/analysis/auto_function.d
@@ -76,10 +76,12 @@ public:
 				auto tok = autoTokens[$ - 1];
 				auto whitespace = tok.column + (tok.text.length ? tok.text.length : str(tok.type).length);
 				auto whitespaceIndex = tok.index + (tok.text.length ? tok.text.length : str(tok.type).length);
-				addErrorMessage([whitespaceIndex, whitespaceIndex + 1], tok.line, [whitespace, whitespace + 1], KEY, MESSAGE_INSERT);
+				addErrorMessage([whitespaceIndex, whitespaceIndex + 1], tok.line, [whitespace, whitespace + 1], KEY, MESSAGE_INSERT,
+					[AutoFix.insertionAt(whitespaceIndex + 1, "void ")]);
 			}
 			else
-				addErrorMessage(autoTokens, KEY, MESSAGE);
+				addErrorMessage(autoTokens, KEY, MESSAGE,
+					[AutoFix.replacement(autoTokens[0], "void")]);
 		}
 	}
 

--- a/src/dscanner/analysis/base.d
+++ b/src/dscanner/analysis/base.d
@@ -407,14 +407,12 @@ public:
 	AutoFix.CodeReplacement[] resolveAutoFix(
 		const Module mod,
 		scope const(Token)[] tokens,
-		const Message message,
 		const AutoFix.ResolveContext context,
 		const AutoFixFormatting formatting,
 	)
 	{
 		cast(void) mod;
 		cast(void) tokens;
-		cast(void) message;
 		cast(void) context;
 		cast(void) formatting;
 		assert(0);

--- a/src/dscanner/analysis/base.d
+++ b/src/dscanner/analysis/base.d
@@ -1,14 +1,159 @@
 module dscanner.analysis.base;
 
+import dparse.ast;
+import dparse.lexer : IdType, str, Token;
+import dsymbol.scope_ : Scope;
+import std.array;
 import std.container;
 import std.string;
-import dparse.ast;
-import std.array;
-import dsymbol.scope_ : Scope;
-import dparse.lexer : Token, str, IdType;
+import std.sumtype;
 
+///
+struct AutoFix
+{
+	///
+	struct CodeReplacement
+	{
+		/// Byte index `[start, end)` within the file what text to replace.
+		/// `start == end` if text is only getting inserted.
+		size_t[2] range;
+		/// The new text to put inside the range. (empty to delete text)
+		string newText;
+	}
+
+	/// Context that the analyzer resolve method can use to generate the
+	/// resolved `CodeReplacement` with.
+	struct ResolveContext
+	{
+		/// Arbitrary analyzer-defined parameters. May grow in the future with
+		/// more items.
+		ulong[3] params;
+		/// For dynamically sized data, may contain binary data.
+		string extraInfo;
+	}
+
+	/// Display name for the UI.
+	string name;
+	/// Either code replacements, sorted by range start, never overlapping, or a
+	/// context that can be passed to `BaseAnalyzer.resolveAutoFix` along with
+	/// the message key from the parent `Message` object.
+	///
+	/// `CodeReplacement[]` should be applied to the code in reverse, otherwise
+	/// an offset to the following start indices must be calculated and be kept
+	/// track of.
+	SumType!(CodeReplacement[], ResolveContext) autofix;
+
+	invariant
+	{
+		autofix.match!(
+			(const CodeReplacement[] replacement)
+			{
+				import std.algorithm : all, isSorted;
+
+				assert(replacement.all!"a.range[0] <= a.range[1]");
+				assert(replacement.isSorted!"a.range[0] < b.range[0]");
+			},
+			(_) {}
+		);
+	}
+
+	static AutoFix replacement(const Token token, string newText, string name = null)
+	{
+		if (!name.length)
+		{
+			auto text = token.text.length ? token.text : str(token.type);
+			if (newText.length)
+				name = "Replace `" ~ text ~ "` with `" ~ newText ~ "`";
+			else
+				name = "Remove `" ~ text ~ "`";
+		}
+		return replacement([token], newText, name);
+	}
+
+	static AutoFix replacement(const BaseNode node, string newText, string name)
+	{
+		return replacement(node.tokens, newText, name);
+	}
+
+	static AutoFix replacement(const Token[] tokens, string newText, string name)
+	in(tokens.length > 0, "must provide at least one token")
+	{
+		auto end = tokens[$ - 1].text.length ? tokens[$ - 1].text : str(tokens[$ - 1].type);
+		return replacement([tokens[0].index, tokens[$ - 1].index + end.length], newText, name);
+	}
+
+	static AutoFix replacement(size_t[2] range, string newText, string name)
+	{
+		AutoFix ret;
+		ret.name = name;
+		ret.autofix = [
+			AutoFix.CodeReplacement(range, newText)
+		];
+		return ret;
+	}
+
+	static AutoFix insertionBefore(const Token token, string content, string name = null)
+	{
+		return insertionAt(token.index, content, name);
+	}
+
+	static AutoFix insertionAfter(const Token token, string content, string name = null)
+	{
+		auto tokenText = token.text.length ? token.text : str(token.type);
+		return insertionAt(token.index + tokenText.length, content, name);
+	}
+
+	static AutoFix insertionAt(size_t index, string content, string name = null)
+	{
+		assert(content.length > 0, "generated auto fix inserting text without content");
+		AutoFix ret;
+		ret.name = name.length
+			? name
+			: content.strip.length
+				? "Insert `" ~ content.strip ~ "`"
+				: "Insert whitespace";
+		ret.autofix = [
+			AutoFix.CodeReplacement([index, index], content)
+		];
+		return ret;
+	}
+
+	AutoFix concat(AutoFix other) const
+	{
+		import std.algorithm : sort;
+
+		AutoFix ret;
+		ret.name = name;
+		CodeReplacement[] concatenated;
+		autofix.match!(
+			(const CodeReplacement[] replacement)
+			{
+				concatenated = replacement.dup;
+			},
+			_ => assert(false, "Cannot concatenate code replacement with late-resolve")
+		);
+		other.autofix.match!(
+			(const CodeReplacement[] concat)
+			{
+				concatenated ~= concat.dup;
+			},
+			_ => assert(false, "Cannot concatenate code replacement with late-resolve")
+		);
+		concatenated.sort!"a.range[0] < b.range[0]";
+		ret.autofix = concatenated;
+		return ret;
+	}
+}
+
+/// A diagnostic message. Each message defines one issue in the file, which
+/// consists of one or more squiggly line ranges within the code, as well as
+/// human readable descriptions and optionally also one or more automatic code
+/// fixes that can be applied.
 struct Message
 {
+	/// A squiggly line range within the code. May be the issue itself if it's
+	/// the `diagnostic` member or supplemental information that can aid the
+	/// user in resolving the issue.
 	struct Diagnostic
 	{
 		/// Name of the file where the warning was triggered.
@@ -21,8 +166,6 @@ struct Message
 		size_t startColumn, endColumn;
 		/// Warning message, may be null for supplemental diagnostics.
 		string message;
-
-		// TODO: add auto-fix suggestion API here
 
 		deprecated("Use startLine instead") alias line = startLine;
 		deprecated("Use startColumn instead") alias column = startColumn;
@@ -74,6 +217,10 @@ struct Message
 	/// Check name
 	string checkName;
 
+	/// Either immediate code changes that can be applied or context to call
+	/// the `BaseAnalyzer.resolveAutoFix` method with.
+	AutoFix[] autofixes;
+
 	deprecated this(string fileName, size_t line, size_t column, string key = null, string message = null, string checkName = null)
 	{
 		diagnostic.fileName = fileName;
@@ -84,19 +231,21 @@ struct Message
 		this.checkName = checkName;
 	}
 
-	this(Diagnostic diagnostic, string key = null, string checkName = null)
+	this(Diagnostic diagnostic, string key = null, string checkName = null, AutoFix[] autofixes = null)
 	{
 		this.diagnostic = diagnostic;
 		this.key = key;
 		this.checkName = checkName;
+		this.autofixes = autofixes;
 	}
 
-	this(Diagnostic diagnostic, Diagnostic[] supplemental, string key = null, string checkName = null)
+	this(Diagnostic diagnostic, Diagnostic[] supplemental, string key = null, string checkName = null, AutoFix[] autofixes = null)
 	{
 		this.diagnostic = diagnostic;
 		this.supplemental = supplemental;
 		this.key = key;
 		this.checkName = checkName;
+		this.autofixes = autofixes;
 	}
 
 	alias diagnostic this;
@@ -151,6 +300,20 @@ public:
 			unittest_.accept(this);
 	}
 
+	AutoFix.CodeReplacement[] resolveAutoFix(
+		const Module mod,
+		const(Token)[] tokens,
+		const Message message,
+		const AutoFix.ResolveContext context
+	)
+	{
+		cast(void) mod;
+		cast(void) tokens;
+		cast(void) message;
+		cast(void) context;
+		assert(0);
+	}
+
 protected:
 
 	bool inAggregate;
@@ -172,40 +335,40 @@ protected:
 		_messages.insert(Message(fileName, line, column, key, message, getName()));
 	}
 
-	void addErrorMessage(const BaseNode node, string key, string message)
+	void addErrorMessage(const BaseNode node, string key, string message, AutoFix[] autofixes = null)
 	{
-		addErrorMessage(Message.Diagnostic.from(fileName, node, message), key);
+		addErrorMessage(Message.Diagnostic.from(fileName, node, message), key, autofixes);
 	}
 
-	void addErrorMessage(const Token token, string key, string message)
+	void addErrorMessage(const Token token, string key, string message, AutoFix[] autofixes = null)
 	{
-		addErrorMessage(Message.Diagnostic.from(fileName, token, message), key);
+		addErrorMessage(Message.Diagnostic.from(fileName, token, message), key, autofixes);
 	}
 
-	void addErrorMessage(const Token[] tokens, string key, string message)
+	void addErrorMessage(const Token[] tokens, string key, string message, AutoFix[] autofixes = null)
 	{
-		addErrorMessage(Message.Diagnostic.from(fileName, tokens, message), key);
+		addErrorMessage(Message.Diagnostic.from(fileName, tokens, message), key, autofixes);
 	}
 
-	void addErrorMessage(size_t[2] index, size_t line, size_t[2] columns, string key, string message)
+	void addErrorMessage(size_t[2] index, size_t line, size_t[2] columns, string key, string message, AutoFix[] autofixes = null)
 	{
-		addErrorMessage(index, [line, line], columns, key, message);
+		addErrorMessage(index, [line, line], columns, key, message, autofixes);
 	}
 
-	void addErrorMessage(size_t[2] index, size_t[2] lines, size_t[2] columns, string key, string message)
+	void addErrorMessage(size_t[2] index, size_t[2] lines, size_t[2] columns, string key, string message, AutoFix[] autofixes = null)
 	{
 		auto d = Message.Diagnostic.from(fileName, index, lines, columns, message);
-		_messages.insert(Message(d, key, getName()));
+		_messages.insert(Message(d, key, getName(), autofixes));
 	}
 
-	void addErrorMessage(Message.Diagnostic diagnostic, string key)
+	void addErrorMessage(Message.Diagnostic diagnostic, string key, AutoFix[] autofixes = null)
 	{
-		_messages.insert(Message(diagnostic, key, getName()));
+		_messages.insert(Message(diagnostic, key, getName(), autofixes));
 	}
 
-	void addErrorMessage(Message.Diagnostic diagnostic, Message.Diagnostic[] supplemental, string key)
+	void addErrorMessage(Message.Diagnostic diagnostic, Message.Diagnostic[] supplemental, string key, AutoFix[] autofixes = null)
 	{
-		_messages.insert(Message(diagnostic, supplemental, key, getName()));
+		_messages.insert(Message(diagnostic, supplemental, key, getName(), autofixes));
 	}
 
 	/**

--- a/src/dscanner/analysis/base.d
+++ b/src/dscanner/analysis/base.d
@@ -276,7 +276,7 @@ public:
 		_messages = new MessageSet;
 	}
 
-	protected string getName()
+	string getName()
 	{
 		assert(0);
 	}

--- a/src/dscanner/analysis/config.d
+++ b/src/dscanner/analysis/config.d
@@ -220,6 +220,69 @@ struct StaticAnalysisConfig
 
 	@INI("Module-specific filters")
 	ModuleFilters filters;
+
+	@INI("Formatting brace style for automatic fixes (allman, otbs, stroustrup, knr)")
+	string brace_style = "allman";
+
+	@INI("Formatting indentation style for automatic fixes (tab, space)")
+	string indentation_style = "tab";
+
+	@INI("Formatting indentation width for automatic fixes (space count, otherwise how wide a tab is)")
+	int indentation_width = 4;
+
+	@INI("Formatting line ending character (lf, cr, crlf)")
+	string eol_style = "lf";
+
+	auto getAutoFixFormattingConfig() const
+	{
+		import dscanner.analysis.base : AutoFixFormatting;
+		import std.array : array;
+		import std.conv : to;
+		import std.range : repeat;
+
+		if (indentation_width < 0)
+			throw new Exception("invalid negative indentation_width");
+
+		AutoFixFormatting ret;
+		ret.braceStyle = brace_style.to!(AutoFixFormatting.BraceStyle);
+		ret.indentationWidth = indentation_width;
+
+		switch (indentation_style)
+		{
+		case "tab":
+			ret.indentation = "\t";
+			break;
+		case "space":
+			static immutable string someSpaces = "                ";
+			if (indentation_width < someSpaces.length)
+				ret.indentation = someSpaces[0 .. indentation_width];
+			else
+				ret.indentation = ' '.repeat(indentation_width).array;
+			break;
+		default:
+			throw new Exception("invalid indentation_style: '" ~ indentation_style ~ "' (expected tab or space)");
+		}
+
+		switch (eol_style)
+		{
+		case "lf":
+		case "LF":
+			ret.eol = "\n";
+			break;
+		case "cr":
+		case "CR":
+			ret.eol = "\r";
+			break;
+		case "crlf":
+		case "CRLF":
+			ret.eol = "\r\n";
+			break;
+		default:
+			throw new Exception("invalid eol_style: '" ~ eol_style ~ "' (expected lf, cr or crlf)");
+		}
+
+		return ret;
+	}
 }
 
 private template ModuleFiltersMixin(A)

--- a/src/dscanner/analysis/del.d
+++ b/src/dscanner/analysis/del.d
@@ -28,7 +28,9 @@ final class DeleteCheck : BaseAnalyzer
 	override void visit(const DeleteExpression d)
 	{
 		addErrorMessage(d.tokens[0], "dscanner.deprecated.delete_keyword",
-				"Avoid using the 'delete' keyword.");
+				"Avoid using the 'delete' keyword.",
+				[AutoFix.replacement(d.tokens[0], `destroy(`, "Replace delete with destroy()")
+					.concat(AutoFix.insertionAfter(d.tokens[$ - 1], ")"))]);
 		d.accept(this);
 	}
 }

--- a/src/dscanner/analysis/del.d
+++ b/src/dscanner/analysis/del.d
@@ -37,8 +37,8 @@ final class DeleteCheck : BaseAnalyzer
 
 unittest
 {
-	import dscanner.analysis.config : StaticAnalysisConfig, Check, disabledConfig;
-	import dscanner.analysis.helpers : assertAnalyzerWarnings;
+	import dscanner.analysis.config : Check, disabledConfig, StaticAnalysisConfig;
+	import dscanner.analysis.helpers : assertAnalyzerWarnings, assertAutoFix;
 
 	StaticAnalysisConfig sac = disabledConfig();
 	sac.delete_check = Check.enabled;
@@ -52,6 +52,26 @@ unittest
 			auto a = new Class();
 			delete a; /+
 			^^^^^^ [warn]: Avoid using the 'delete' keyword. +/
+		}
+	}c, sac);
+
+	assertAutoFix(q{
+		void testDelete()
+		{
+			int[int] data = [1 : 2];
+			delete data[1]; // fix
+
+			auto a = new Class();
+			delete a; // fix
+		}
+	}c, q{
+		void testDelete()
+		{
+			int[int] data = [1 : 2];
+			destroy(data[1]); // fix
+
+			auto a = new Class();
+			destroy(a); // fix
 		}
 	}c, sac);
 

--- a/src/dscanner/analysis/duplicate_attribute.d
+++ b/src/dscanner/analysis/duplicate_attribute.d
@@ -227,5 +227,40 @@ unittest
 		}
 	}c, sac);
 
+
+	assertAutoFix(q{
+		class ExampleAttributes
+		{
+			@property @property bool aaa() {} // fix
+			bool bbb() @safe @safe {} // fix
+			@system bool ccc() @system {} // fix
+			@trusted bool ddd() @trusted {} // fix
+		}
+
+		class ExamplePureNoThrow
+		{
+			pure pure bool bbb() {} // fix
+			bool ccc() pure pure {} // fix
+			nothrow nothrow bool ddd() {} // fix
+			bool eee() nothrow nothrow {} // fix
+		}
+	}c, q{
+		class ExampleAttributes
+		{
+			@property bool aaa() {} // fix
+			bool bbb() @safe {} // fix
+			@system bool ccc() {} // fix
+			@trusted bool ddd() {} // fix
+		}
+
+		class ExamplePureNoThrow
+		{
+			pure bool bbb() {} // fix
+			bool ccc() pure {} // fix
+			nothrow bool ddd() {} // fix
+			bool eee() nothrow {} // fix
+		}
+	}c, sac);
+
 	stderr.writeln("Unittest for DuplicateAttributeCheck passed.");
 }

--- a/src/dscanner/analysis/duplicate_attribute.d
+++ b/src/dscanner/analysis/duplicate_attribute.d
@@ -93,7 +93,8 @@ final class DuplicateAttributeCheck : BaseAnalyzer
 		if (hasAttribute)
 		{
 			string message = "Attribute '%s' is duplicated.".format(attributeName);
-			addErrorMessage(tokens, "dscanner.unnecessary.duplicate_attribute", message);
+			addErrorMessage(tokens, "dscanner.unnecessary.duplicate_attribute", message,
+				[AutoFix.replacement(tokens, "", "Remove second attribute " ~ attributeName)]);
 		}
 
 		// Mark it as having that attribute

--- a/src/dscanner/analysis/enumarrayliteral.d
+++ b/src/dscanner/analysis/enumarrayliteral.d
@@ -8,7 +8,7 @@ module dscanner.analysis.enumarrayliteral;
 import dparse.ast;
 import dparse.lexer;
 import dscanner.analysis.base;
-import std.algorithm : canFind, map;
+import std.algorithm : find, map;
 import dsymbol.scope_ : Scope;
 
 void doNothing(string, size_t, size_t, string, bool)
@@ -35,7 +35,8 @@ final class EnumArrayLiteralCheck : BaseAnalyzer
 
 	override void visit(const AutoDeclaration autoDec)
 	{
-		if (autoDec.storageClasses.canFind!(a => a.token == tok!"enum"))
+		auto enumToken = autoDec.storageClasses.find!(a => a.token == tok!"enum");
+		if (enumToken.length)
 		{
 			foreach (part; autoDec.parts)
 			{
@@ -49,7 +50,10 @@ final class EnumArrayLiteralCheck : BaseAnalyzer
 						"dscanner.performance.enum_array_literal",
 						"This enum may lead to unnecessary allocation at run-time."
 						~ " Use 'static immutable "
-						~ part.identifier.text ~ " = [ ...' instead.");
+						~ part.identifier.text ~ " = [ ...' instead.",
+						[
+							AutoFix.replacement(enumToken[0].token, "static immutable")
+						]);
 			}
 		}
 		autoDec.accept(this);

--- a/src/dscanner/analysis/enumarrayliteral.d
+++ b/src/dscanner/analysis/enumarrayliteral.d
@@ -59,3 +59,25 @@ final class EnumArrayLiteralCheck : BaseAnalyzer
 		autoDec.accept(this);
 	}
 }
+
+unittest
+{
+	import dscanner.analysis.config : Check, disabledConfig, StaticAnalysisConfig;
+	import dscanner.analysis.helpers : assertAnalyzerWarnings, assertAutoFix;
+	import std.stdio : stderr;
+
+	StaticAnalysisConfig sac = disabledConfig();
+	sac.enum_array_literal_check = Check.enabled;
+	assertAnalyzerWarnings(q{
+		enum x = [1, 2, 3]; /+
+		         ^^^^^^^^^ [warn]: This enum may lead to unnecessary allocation at run-time. Use 'static immutable x = [ ...' instead. +/
+	}c, sac);
+
+	assertAutoFix(q{
+		enum x = [1, 2, 3]; // fix
+	}c, q{
+		static immutable x = [1, 2, 3]; // fix
+	}c, sac);
+
+	stderr.writeln("Unittest for EnumArrayLiteralCheck passed.");
+}

--- a/src/dscanner/analysis/explicitly_annotated_unittests.d
+++ b/src/dscanner/analysis/explicitly_annotated_unittests.d
@@ -62,10 +62,10 @@ final class ExplicitlyAnnotatedUnittestCheck : BaseAnalyzer
 
 unittest
 {
-	import std.stdio : stderr;
+	import dscanner.analysis.config : Check, disabledConfig, StaticAnalysisConfig;
+	import dscanner.analysis.helpers : assertAnalyzerWarnings, assertAutoFix;
 	import std.format : format;
-	import dscanner.analysis.config : StaticAnalysisConfig, Check, disabledConfig;
-	import dscanner.analysis.helpers : assertAnalyzerWarnings;
+	import std.stdio : stderr;
 
 	StaticAnalysisConfig sac = disabledConfig();
 	sac.explicitly_annotated_unittests = Check.enabled;
@@ -100,6 +100,28 @@ unittest
 		ExplicitlyAnnotatedUnittestCheck.MESSAGE,
 		ExplicitlyAnnotatedUnittestCheck.MESSAGE,
 	), sac);
+
+
+	// nested
+	assertAutoFix(q{
+		unittest {} // fix:0
+		pure nothrow @nogc unittest {} // fix:0
+
+		struct Foo
+		{
+			unittest {} // fix:1
+			pure nothrow @nogc unittest {} // fix:1
+		}
+	}c, q{
+		@safe unittest {} // fix:0
+		pure nothrow @nogc @safe unittest {} // fix:0
+
+		struct Foo
+		{
+			@system unittest {} // fix:1
+			pure nothrow @nogc @system unittest {} // fix:1
+		}
+	}c, sac);
 
 	stderr.writeln("Unittest for ExplicitlyAnnotatedUnittestCheck passed.");
 }

--- a/src/dscanner/analysis/explicitly_annotated_unittests.d
+++ b/src/dscanner/analysis/explicitly_annotated_unittests.d
@@ -44,7 +44,14 @@ final class ExplicitlyAnnotatedUnittestCheck : BaseAnalyzer
 				}
 			}
 			if (!isSafeOrSystem)
-				addErrorMessage(decl.unittest_.findTokenForDisplay(tok!"unittest"), KEY, MESSAGE);
+			{
+				auto token = decl.unittest_.findTokenForDisplay(tok!"unittest");
+				addErrorMessage(token, KEY, MESSAGE,
+					[
+						AutoFix.insertionBefore(token[0], "@safe ", "Mark unittest @safe"),
+						AutoFix.insertionBefore(token[0], "@system ", "Mark unittest @system")
+					]);
+			}
 		}
 		decl.accept(this);
 	}

--- a/src/dscanner/analysis/final_attribute.d
+++ b/src/dscanner/analysis/final_attribute.d
@@ -57,7 +57,8 @@ private:
 	void addError(T)(const Token finalToken, T t, string msg)
 	{
 		import std.format : format;
-		addErrorMessage(finalToken.type ? finalToken : t.name, KEY, MSGB.format(msg));
+		addErrorMessage(finalToken.type ? finalToken : t.name, KEY, MSGB.format(msg),
+				[AutoFix.replacement(finalToken, "")]);
 	}
 
 public:

--- a/src/dscanner/analysis/function_attributes.d
+++ b/src/dscanner/analysis/function_attributes.d
@@ -223,5 +223,58 @@ unittest
 		}
 	}c, sac);
 
+
+	assertAutoFix(q{
+		int foo() @property { return 0; }
+
+		class ClassName {
+			const int confusingConst() { return 0; } // fix:0
+			const int confusingConst() { return 0; } // fix:1
+
+			int bar() @property { return 0; } // fix:0
+			int bar() @property { return 0; } // fix:1
+			int bar() @property { return 0; } // fix:2
+		}
+
+		struct StructName {
+			int bar() @property { return 0; } // fix:0
+		}
+
+		union UnionName {
+			int bar() @property { return 0; } // fix:0
+		}
+
+		interface InterfaceName {
+			int bar() @property; // fix:0
+
+			abstract int method(); // fix
+		}
+	}c, q{
+		int foo() @property { return 0; }
+
+		class ClassName {
+			int confusingConst() const { return 0; } // fix:0
+			const(int) confusingConst() { return 0; } // fix:1
+
+			int bar() const @property { return 0; } // fix:0
+			int bar() inout @property { return 0; } // fix:1
+			int bar() immutable @property { return 0; } // fix:2
+		}
+
+		struct StructName {
+			int bar() const @property { return 0; } // fix:0
+		}
+
+		union UnionName {
+			int bar() const @property { return 0; } // fix:0
+		}
+
+		interface InterfaceName {
+			int bar() const @property; // fix:0
+
+			int method(); // fix
+		}
+	}c, sac);
+
 	stderr.writeln("Unittest for FunctionAttributeCheck passed.");
 }

--- a/src/dscanner/analysis/length_subtraction.d
+++ b/src/dscanner/analysis/length_subtraction.d
@@ -65,5 +65,19 @@ unittest
 				writeln("something");
 		}
 	}c, sac);
+
+	assertAutoFix(q{
+		void testSizeT()
+		{
+			if (i < a.length - 1) // fix
+				writeln("something");
+		}
+	}c, q{
+		void testSizeT()
+		{
+			if (i < cast(ptrdiff_t) a.length - 1) // fix
+				writeln("something");
+		}
+	}c, sac);
 	stderr.writeln("Unittest for IfElseSameCheck passed.");
 }

--- a/src/dscanner/analysis/length_subtraction.d
+++ b/src/dscanner/analysis/length_subtraction.d
@@ -41,7 +41,10 @@ final class LengthSubtractionCheck : BaseAnalyzer
 					|| l.identifierOrTemplateInstance.identifier.text != "length")
 				goto end;
 			addErrorMessage(addExpression, "dscanner.suspicious.length_subtraction",
-					"Avoid subtracting from '.length' as it may be unsigned.");
+					"Avoid subtracting from '.length' as it may be unsigned.",
+					[
+						AutoFix.insertionBefore(l.tokens[0], "cast(ptrdiff_t) ", "Cast to ptrdiff_t")
+					]);
 		}
 	end:
 		addExpression.accept(this);

--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -119,8 +119,10 @@ private string formatBase(string format, Message.Diagnostic diagnostic, scope co
 	s = s.replace("{filepath}", diagnostic.fileName);
 	s = s.replace("{line}", to!string(diagnostic.startLine));
 	s = s.replace("{column}", to!string(diagnostic.startColumn));
+	s = s.replace("{startIndex}", to!string(diagnostic.startIndex));
 	s = s.replace("{endLine}", to!string(diagnostic.endLine));
 	s = s.replace("{endColumn}", to!string(diagnostic.endColumn));
+	s = s.replace("{endIndex}", to!string(diagnostic.endIndex));
 	s = s.replace("{message}", diagnostic.message);
 	s = s.replace("{context}", diagnostic.formatContext(cast(const(char)[]) code, color));
 	return s;

--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -775,8 +775,10 @@ MessageSet analyze(string fileName, const Module m, const StaticAnalysisConfig a
 
 AutoFix.CodeReplacement[] resolveAutoFix(const Message message,
 	const AutoFix.ResolveContext resolve, string fileName,
-	ref ModuleCache moduleCache, const(Token)[] tokens, const Module m,
-	const StaticAnalysisConfig analysisConfig)
+	ref ModuleCache moduleCache, scope const(char)[] rawCode,
+	scope const(Token)[] tokens, const Module m,
+	const StaticAnalysisConfig analysisConfig,
+	const AutoFixFormatting formattingConfig)
 {
 	import dsymbol.symbol : DSymbol;
 
@@ -797,7 +799,7 @@ AutoFix.CodeReplacement[] resolveAutoFix(const Message message,
 	{
 		if (check.getName() == message.checkName)
 		{
-			return check.resolveAutoFix(m, tokens, message, resolve);
+			return check.resolveAutoFix(m, rawCode, tokens, message, resolve, formattingConfig);
 		}
 	}
 

--- a/src/dscanner/analysis/static_if_else.d
+++ b/src/dscanner/analysis/static_if_else.d
@@ -65,8 +65,8 @@ final class StaticIfElse : BaseAnalyzer
 
 unittest
 {
-	import dscanner.analysis.helpers : assertAnalyzerWarnings;
-	import dscanner.analysis.config : StaticAnalysisConfig, Check, disabledConfig;
+	import dscanner.analysis.config : Check, disabledConfig, StaticAnalysisConfig;
+	import dscanner.analysis.helpers : assertAnalyzerWarnings, assertAutoFix;
 	import std.stdio : stderr;
 
 	StaticAnalysisConfig sac = disabledConfig();
@@ -89,6 +89,22 @@ unittest
 				if (true)
 					auto b = 1;
 			}
+		}
+	}c, sac);
+
+	assertAutoFix(q{
+		void foo() {
+			static if (false)
+				auto a = 0;
+			else if (true) // fix
+				auto b = 1;
+		}
+	}c, q{
+		void foo() {
+			static if (false)
+				auto a = 0;
+			else static if (true) // fix
+				auto b = 1;
 		}
 	}c, sac);
 

--- a/src/dscanner/analysis/static_if_else.d
+++ b/src/dscanner/analysis/static_if_else.d
@@ -63,7 +63,6 @@ final class StaticIfElse : BaseAnalyzer
 	override AutoFix.CodeReplacement[] resolveAutoFix(
 		const Module mod,
 		scope const(Token)[] tokens,
-		const Message message,
 		const AutoFix.ResolveContext context,
 		const AutoFixFormatting formatting,
 	)

--- a/src/dscanner/analysis/static_if_else.d
+++ b/src/dscanner/analysis/static_if_else.d
@@ -48,7 +48,11 @@ final class StaticIfElse : BaseAnalyzer
 		auto tokens = ifStmt.tokens[0 .. 1];
 		// extend one token to include `else` before this if
 		tokens = (tokens.ptr - 1)[0 .. 2];
-		addErrorMessage(tokens, KEY, "Mismatched static if. Use 'else static if' here.");
+		addErrorMessage(tokens, KEY, "Mismatched static if. Use 'else static if' here.",
+			[
+				AutoFix.insertionBefore(tokens[$ - 1], "static "),
+				// TODO: make if explicit with block {}, using correct indentation
+			]);
 	}
 
 	const(IfStatement) getIfStatement(const ConditionalStatement cc)

--- a/src/dscanner/analysis/static_if_else.d
+++ b/src/dscanner/analysis/static_if_else.d
@@ -62,7 +62,6 @@ final class StaticIfElse : BaseAnalyzer
 
 	override AutoFix.CodeReplacement[] resolveAutoFix(
 		const Module mod,
-		scope const(char)[] rawCode,
 		scope const(Token)[] tokens,
 		const Message message,
 		const AutoFix.ResolveContext context,
@@ -77,7 +76,7 @@ final class StaticIfElse : BaseAnalyzer
 		if (beforeElse == -1 || lastToken == -1)
 			throw new Exception("got different tokens than what was used to generate this autofix");
 
-		auto indentation = getLineIndentation(rawCode, tokens, tokens[beforeElse].line);
+		auto indentation = getLineIndentation(tokens, tokens[beforeElse].line, formatting);
 
 		string beforeIf = formatting.getWhitespaceBeforeOpeningBrace(indentation, false)
 			~ "{" ~ formatting.eol ~ indentation;

--- a/src/dscanner/main.d
+++ b/src/dscanner/main.d
@@ -461,6 +461,8 @@ Options:
         - {endLine}: end line number, 1-based, inclusive
         - {column}: start column on start line, 1-based, in bytes
         - {endColumn}: end column on end line, 1-based, in bytes, exclusive
+        - {startIndex}: start file byte offset, 0-based
+        - {endIndex}: end file byte offset, 0-based
         - {type}: "error" or "warn", uppercase variants: {Type}, {TYPE},
         - {type2}: "error" or "warning", uppercase variants: {Type2}, {TYPE2}
         - {message}: human readable message such as "Variable c is never used."

--- a/src/dscanner/main.d
+++ b/src/dscanner/main.d
@@ -64,6 +64,7 @@ else
 	bool report;
 	bool skipTests;
 	bool applySingleFixes;
+	string resolveMessage;
 	string reportFormat;
 	string reportFile;
 	string symbolName;
@@ -98,6 +99,7 @@ else
 				"report", &report,
 				"reportFormat", &reportFormat,
 				"reportFile", &reportFile,
+				"resolveMessage", &resolveMessage,
 				"applySingle", &applySingleFixes,
 				"I", &importPaths,
 				"version", &printVersion,
@@ -213,7 +215,7 @@ else
 
 	immutable optionCount = count!"a"([sloc, highlight, ctags, tokenCount,
 			syntaxCheck, ast, imports, outline, tokenDump, styleCheck,
-			defaultConfig, report, autofix,
+			defaultConfig, report, autofix, resolveMessage.length,
 			symbolName !is null, etags, etagsAll, recursiveImports,
 	]);
 	if (optionCount > 1)
@@ -286,7 +288,7 @@ else
 	{
 		stdout.printEtags(etagsAll, expandArgs(args));
 	}
-	else if (styleCheck || autofix)
+	else if (styleCheck || autofix || resolveMessage.length)
 	{
 		StaticAnalysisConfig config = defaultStaticAnalysisConfig();
 		string s = configLocation is null ? getConfigurationLocation() : configLocation;
@@ -298,6 +300,11 @@ else
 		if (autofix)
 		{
 			return .autofix(expandArgs(args), config, errorFormat, cache, moduleCache, applySingleFixes) ? 1 : 0;
+		}
+		else if (resolveMessage.length)
+		{
+			listAutofixes(config, resolveMessage, usingStdin, usingStdin ? "stdin" : args[1], &cache, moduleCache);
+			return 0;
 		}
 		else if (report)
 		{

--- a/src/dscanner/utils.d
+++ b/src/dscanner/utils.d
@@ -80,6 +80,19 @@ ubyte[] readFile(string fileName)
 	return sourceCode;
 }
 
+void writeFileSafe(string filename, scope const(ubyte)[] content)
+{
+	import std.file : copy, PreserveAttributes, remove, write;
+	import std.path : baseName, buildPath, dirName;
+
+	string tempName = buildPath(filename.dirName, "." ~ filename.baseName ~ "~");
+
+	// FIXME: we are removing the optional BOM here
+	copy(filename, tempName, PreserveAttributes.yes);
+	write(filename, content);
+	remove(tempName);
+}
+
 string[] expandArgs(string[] args)
 {
 	import std.file : isFile, FileException, dirEntries, SpanMode;

--- a/tests/dscanner.ini
+++ b/tests/dscanner.ini
@@ -1,0 +1,113 @@
+; Configure which static analysis checks are enabled
+[analysis.config.StaticAnalysisConfig]
+; Check variable, class, struct, interface, union, and function names against the Phobos style guide
+style_check="disabled"
+; Check for array literals that cause unnecessary allocation
+enum_array_literal_check="enabled"
+; Check for poor exception handling practices
+exception_check="enabled"
+; Check for use of the deprecated 'delete' keyword
+delete_check="enabled"
+; Check for use of the deprecated floating point operators
+float_operator_check="enabled"
+; Check number literals for readability
+number_style_check="enabled"
+; Checks that opEquals, opCmp, toHash, and toString are either const, immutable, or inout.
+object_const_check="enabled"
+; Checks for .. expressions where the left side is larger than the right.
+backwards_range_check="enabled"
+; Checks for if statements whose 'then' block is the same as the 'else' block
+if_else_same_check="enabled"
+; Checks for some problems with constructors
+constructor_check="enabled"
+; Checks for unused variables
+unused_variable_check="enabled"
+; Checks for unused labels
+unused_label_check="enabled"
+; Checks for unused function parameters
+unused_parameter_check="enabled"
+; Checks for duplicate attributes
+duplicate_attribute="enabled"
+; Checks that opEquals and toHash are both defined or neither are defined
+opequals_tohash_check="enabled"
+; Checks for subtraction from .length properties
+length_subtraction_check="enabled"
+; Checks for methods or properties whose names conflict with built-in properties
+builtin_property_names_check="enabled"
+; Checks for confusing code in inline asm statements
+asm_style_check="enabled"
+; Checks for confusing logical operator precedence
+logical_precedence_check="enabled"
+; Checks for undocumented public declarations
+undocumented_declaration_check="disabled"
+; Checks for poor placement of function attributes
+function_attribute_check="enabled"
+; Checks for use of the comma operator
+comma_expression_check="enabled"
+; Checks for local imports that are too broad. Only accurate when checking code used with D versions older than 2.071.0
+local_import_check="enabled"
+; Checks for variables that could be declared immutable
+could_be_immutable_check="enabled"
+; Checks for redundant expressions in if statements
+redundant_if_check="enabled"
+; Checks for redundant parenthesis
+redundant_parens_check="enabled"
+; Checks for mismatched argument and parameter names
+mismatched_args_check="enabled"
+; Checks for labels with the same name as variables
+label_var_same_name_check="enabled"
+; Checks for lines longer than `max_line_length` characters
+long_line_check="enabled"
+; Checks for assignment to auto-ref function parameters
+auto_ref_assignment_check="enabled"
+; Checks for incorrect infinite range definitions
+incorrect_infinite_range_check="enabled"
+; Checks for asserts that are always true
+useless_assert_check="enabled"
+; Check for uses of the old-style alias syntax
+alias_syntax_check="enabled"
+; Checks for else if that should be else static if
+static_if_else_check="enabled"
+; Check for unclear lambda syntax
+lambda_return_check="enabled"
+; Check for auto function without return statement
+auto_function_check="enabled"
+; Check for sortedness of imports
+imports_sortedness="enabled"
+; Check for explicitly annotated unittests
+explicitly_annotated_unittests="enabled"
+; Check for properly documented public functions (Returns, Params)
+properly_documented_public_functions="enabled"
+; Check for useless usage of the final attribute
+final_attribute_check="enabled"
+; Check for virtual calls in the class constructors
+vcall_in_ctor="enabled"
+; Check for useless user defined initializers
+useless_initializer="enabled"
+; Check allman brace style
+allman_braces_check="enabled"
+; Check for redundant attributes
+redundant_attributes_check="enabled"
+; Check public declarations without a documented unittest
+has_public_example="enabled"
+; Check for asserts without an explanatory message
+assert_without_msg="enabled"
+; Check indent of if constraints
+if_constraints_indent="enabled"
+; Check for @trusted applied to a bigger scope than a single function
+trust_too_much="enabled"
+; Check for redundant storage classes on variable declarations
+redundant_storage_classes="enabled"
+; Check for unused function return values
+unused_result="enabled"
+; Enable cyclomatic complexity check
+cyclomatic_complexity="enabled"
+; Check for function bodies on discord functions
+body_on_disabled_func_check="enabled"
+; Formatting brace style for automatic fixes (allman, otbs, stroustrup, knr)
+brace_style="allman"
+; Formatting indentation style for automatic fixes (tabs, spaces)
+indentation_style="tab"
+; Formatting line ending character (lf, cr, crlf)
+eol_style="lf"
+

--- a/tests/it.sh
+++ b/tests/it.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+DSCANNER_DIR="$(dirname -- $( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd ))"
+dub build --root="$DSCANNER_DIR"
+
+cd "$DSCANNER_DIR/tests"
+
+# IDE APIs
+# --------
+# checking that reporting format stays consistent or only gets extended
+diff <(jq -S . <(../bin/dscanner --report it/source_autofix.d)) <(jq -S . it/source_autofix.report.json)
+diff <(jq -S . <(../bin/dscanner --resolveMessage b16 it/source_autofix.d)) <(jq -S . it/source_autofix.autofix.json)
+
+

--- a/tests/it/source_autofix.autofix.json
+++ b/tests/it/source_autofix.autofix.json
@@ -1,0 +1,38 @@
+[
+	{
+		"name": "Mark function `const`",
+		"replacements": [
+			{
+				"newText": " const",
+				"range": [
+					24,
+					24
+				]
+			}
+		]
+	},
+	{
+		"name": "Mark function `inout`",
+		"replacements": [
+			{
+				"newText": " inout",
+				"range": [
+					24,
+					24
+				]
+			}
+		]
+	},
+	{
+		"name": "Mark function `immutable`",
+		"replacements": [
+			{
+				"newText": " immutable",
+				"range": [
+					24,
+					24
+				]
+			}
+		]
+	}
+]

--- a/tests/it/source_autofix.d
+++ b/tests/it/source_autofix.d
@@ -1,0 +1,6 @@
+struct S
+{
+	int myProp() @property
+	{
+	}
+}

--- a/tests/it/source_autofix.report.json
+++ b/tests/it/source_autofix.report.json
@@ -1,0 +1,26 @@
+{
+	"classCount": 0,
+	"functionCount": 1,
+	"interfaceCount": 0,
+	"issues": [
+		{
+			"column": 6,
+			"endColumn": 12,
+			"endIndex": 22,
+			"endLine": 3,
+			"fileName": "it\/source_autofix.d",
+			"index": 16,
+			"key": "dscanner.confusing.function_attributes",
+			"line": 3,
+			"message": "Zero-parameter '@property' function should be marked 'const', 'inout', or 'immutable'.",
+			"name": "function_attribute_check",
+			"supplemental": [],
+			"type": "warn"
+		}
+	],
+	"lineOfCodeCount": 0,
+	"statementCount": 0,
+	"structCount": 1,
+	"templateCount": 0,
+	"undocumentedPublicSymbols": 0
+}


### PR DESCRIPTION
fix #351

The error emission side can use this quite trivially, as shown in the diffs.

TODO: (this or future PRs)

- [x] add CLI interface to interactively apply to issues (`dscanner fix source/`)
- [x] expose IDE API over CLI
- [x] make autofixes whitespace aware (test implementation in serve-d right now)
	- [x] collapse neighboring whitespace in edits
	- [x] add indent/dedent APIs (need to be aware of format settings)
- [x] add unittests

Samples:

![2023-07-06-01-49-16](https://github.com/dlang-community/D-Scanner/assets/2035977/f329d5ec-0eaf-456a-98e6-09492333ffab)
![2023-07-06-01-49-40](https://github.com/dlang-community/D-Scanner/assets/2035977/38241594-cfac-487a-bab3-e6ee5af6b6c1)
![2023-07-06-01-49-49](https://github.com/dlang-community/D-Scanner/assets/2035977/580f1f1a-87f2-4698-b5c7-cb973685a8d6)
![2023-07-06-01-51-32](https://github.com/dlang-community/D-Scanner/assets/2035977/28e0a463-3b73-4c57-a63f-b1c82d38ac1b)
![2023-07-06-01-52-35](https://github.com/dlang-community/D-Scanner/assets/2035977/7d17c594-293f-45de-b83b-d83fdf7fe670)
![2023-07-06-01-53-31](https://github.com/dlang-community/D-Scanner/assets/2035977/fdb86e0b-4195-4e06-94ff-ce06402eb9eb)