### PR TITLE
fix case/default scopes, fix #913

### DIFF
--- a/src/dscanner/analysis/base.d
+++ b/src/dscanner/analysis/base.d
@@ -525,12 +525,14 @@ public:
 	mixin ScopedVisit!BlockStatement;
 	mixin ScopedVisit!ForeachStatement;
 	mixin ScopedVisit!ForStatement;
-	mixin ScopedVisit!IfStatement;
 	mixin ScopedVisit!Module;
 	mixin ScopedVisit!StructBody;
 	mixin ScopedVisit!TemplateDeclaration;
 	mixin ScopedVisit!WithStatement;
 	mixin ScopedVisit!WhileStatement;
+	mixin ScopedVisit!DoStatement;
+	// mixin ScopedVisit!SpecifiedFunctionBody; // covered by BlockStatement
+	mixin ScopedVisit!ShortenedFunctionBody;
 
 	override void visit(const SwitchStatement switchStatement)
 	{
@@ -538,6 +540,23 @@ public:
 		scope (exit)
 			switchStack.length--;
 		switchStatement.accept(this);
+	}
+
+	override void visit(const IfStatement ifStatement)
+	{
+		pushScopeImpl();
+		if (ifStatement.condition)
+			ifStatement.condition.accept(this);
+		if (ifStatement.thenStatement)
+			ifStatement.thenStatement.accept(this);
+		popScopeImpl();
+
+		if (ifStatement.elseStatement)
+		{
+			pushScopeImpl();
+			ifStatement.elseStatement.accept(this);
+			popScopeImpl();
+		}
 	}
 
 	static foreach (T; AliasSeq!(CaseStatement, DefaultStatement, CaseRangeStatement))

--- a/src/dscanner/analysis/label_var_same_name_check.d
+++ b/src/dscanner/analysis/label_var_same_name_check.d
@@ -13,7 +13,7 @@ import dscanner.analysis.helpers;
 /**
  * Checks for labels and variables that have the same name.
  */
-final class LabelVarNameCheck : BaseAnalyzer
+final class LabelVarNameCheck : ScopedBaseAnalyzer
 {
 	mixin AnalyzerInfo!"label_var_same_name_check";
 
@@ -21,14 +21,6 @@ final class LabelVarNameCheck : BaseAnalyzer
 	{
 		super(fileName, sc, skipTests);
 	}
-
-	mixin ScopedVisit!Module;
-	mixin ScopedVisit!BlockStatement;
-	mixin ScopedVisit!StructBody;
-	mixin ScopedVisit!CaseStatement;
-	mixin ScopedVisit!ForStatement;
-	mixin ScopedVisit!IfStatement;
-	mixin ScopedVisit!TemplateDeclaration;
 
 	mixin AggregateVisit!ClassDeclaration;
 	mixin AggregateVisit!StructDeclaration;
@@ -64,7 +56,7 @@ final class LabelVarNameCheck : BaseAnalyzer
 		--conditionalDepth;
 	}
 
-	alias visit = BaseAnalyzer.visit;
+	alias visit = ScopedBaseAnalyzer.visit;
 
 private:
 
@@ -77,16 +69,6 @@ private:
 			pushAggregateName(n.name);
 			n.accept(this);
 			popAggregateName();
-		}
-	}
-
-	template ScopedVisit(NodeType)
-	{
-		override void visit(const NodeType n)
-		{
-			pushScope();
-			n.accept(this);
-			popScope();
 		}
 	}
 
@@ -128,12 +110,12 @@ private:
 		return stack[$ - 1];
 	}
 
-	void pushScope()
+	protected override void pushScope()
 	{
 		stack.length++;
 	}
 
-	void popScope()
+	protected override void popScope()
 	{
 		stack.length--;
 	}
@@ -276,6 +258,21 @@ unittest
 {
 	int aa;
 	struct a { int a; }
+}
+
+unittest
+{
+	switch (1) {
+	case 1:
+		int x, c1;
+		break;
+	case 2:
+		int x, c2;
+		break;
+	default:
+		int x, def;
+		break;
+	}
 }
 
 }c, sac);

--- a/src/dscanner/analysis/redundant_attributes.d
+++ b/src/dscanner/analysis/redundant_attributes.d
@@ -17,7 +17,7 @@ import std.range : empty, front, walkLength;
 /**
  * Checks for redundant attributes. At the moment only visibility attributes.
  */
-final class RedundantAttributesCheck : BaseAnalyzer
+final class RedundantAttributesCheck : ScopedBaseAnalyzer
 {
 	mixin AnalyzerInfo!"redundant_attributes_check";
 
@@ -67,15 +67,8 @@ final class RedundantAttributesCheck : BaseAnalyzer
 		}
 	}
 
-	alias visit = BaseAnalyzer.visit;
+	alias visit = ScopedBaseAnalyzer.visit;
 
-	mixin ScopedVisit!Module;
-	mixin ScopedVisit!BlockStatement;
-	mixin ScopedVisit!StructBody;
-	mixin ScopedVisit!CaseStatement;
-	mixin ScopedVisit!ForStatement;
-	mixin ScopedVisit!IfStatement;
-	mixin ScopedVisit!TemplateDeclaration;
 	mixin ScopedVisit!ConditionalDeclaration;
 
 private:
@@ -153,22 +146,12 @@ private:
 		return currentAttributes.map!(a => a.attribute.type.str).joiner(",").to!string;
 	}
 
-	template ScopedVisit(NodeType)
-	{
-		override void visit(const NodeType n)
-		{
-			pushScope();
-			n.accept(this);
-			popScope();
-		}
-	}
-
-	void pushScope()
+	protected override void pushScope()
 	{
 		stack.length++;
 	}
 
-	void popScope()
+	protected override void popScope()
 	{
 		stack.length--;
 	}


### PR DESCRIPTION
introduces a new ScopedBaseAnalyzer base class, which defines abstract pushScope & popScope methods that can be used by checks to clear/set variable scopes. Adds new unittests for the scope checking and makes the label_var_same_name_check and redundant_attributes checks reuse it.

Future-proofs us in case libdparse case/default parsing changes.