### PR TITLE
fix infinite allocating in context formatter

### DIFF
--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -133,7 +133,8 @@ private string formatContext(Message.Diagnostic diagnostic, scope const(char)[] 
 	import std.string : indexOf, lastIndexOf;
 
 	if (diagnostic.startIndex >= diagnostic.endIndex || diagnostic.endIndex > code.length
-		|| diagnostic.startColumn >= diagnostic.endColumn || diagnostic.endColumn == 0)
+		|| diagnostic.startColumn >= diagnostic.endColumn || diagnostic.endColumn == 0
+		|| diagnostic.startColumn == 0)
 		return null;
 
 	auto lineStart = code.lastIndexOf('\n', diagnostic.startIndex) + 1;


### PR DESCRIPTION
happens when token ranges are not initialized and attaching issues to their ast nodes