### PR TITLE
Disable auto_function_check by default

### DIFF
--- a/src/dscanner/analysis/auto_function.d
+++ b/src/dscanner/analysis/auto_function.d
@@ -82,7 +82,8 @@ public:
 			}
 			else
 				addErrorMessage(autoTokens, KEY, MESSAGE,
-					[AutoFix.replacement(autoTokens[0], "void")]);
+					[AutoFix.replacement(autoTokens[0], "", "Replace `auto` with `void`")
+						.concat(AutoFix.insertionAt(decl.name.index, "void "))]);
 		}
 	}
 
@@ -277,12 +278,14 @@ unittest
 
 
 	assertAutoFix(q{
+		auto ref doStuff(){} // fix
 		auto doStuff(){} // fix
 		@property doStuff(){} // fix
 		@safe doStuff(){} // fix
 		@Custom
 		auto doStuff(){} // fix
 	}c, q{
+		ref void doStuff(){} // fix
 		void doStuff(){} // fix
 		@property void doStuff(){} // fix
 		@safe void doStuff(){} // fix

--- a/src/dscanner/analysis/config.d
+++ b/src/dscanner/analysis/config.d
@@ -165,7 +165,7 @@ struct StaticAnalysisConfig
 	string lambda_return_check = Check.enabled;
 
 	@INI("Check for auto function without return statement")
-	string auto_function_check = Check.enabled;
+	string auto_function_check = Check.disabled;
 
 	@INI("Check for sortedness of imports")
 	string imports_sortedness = Check.disabled;


### PR DESCRIPTION
Since it may be used to auto-infer function attributes.

Fix autofix for when `auto` comes before other storage classes.