### PR TITLE
fix unused variable check for unitthreaded checks

### DIFF
--- a/src/dscanner/analysis/unused.d
+++ b/src/dscanner/analysis/unused.d
@@ -79,6 +79,13 @@ abstract class UnusedIdentifierCheck : BaseAnalyzer
 	mixin PartsUseVariables!ThrowExpression;
 	mixin PartsUseVariables!CastExpression;
 
+	override void dynamicDispatch(const ExpressionNode n)
+	{
+		interestDepth++;
+		super.dynamicDispatch(n);
+		interestDepth--;
+	}
+
 	override void visit(const SwitchStatement switchStatement)
 	{
 		if (switchStatement.expression !is null)

--- a/src/dscanner/analysis/unused_variable.d
+++ b/src/dscanner/analysis/unused_variable.d
@@ -125,6 +125,12 @@ final class UnusedVariableCheck : UnusedStorageCheck
 		__traits(isPOD);
 	}
 
+	void unitthreaded()
+	{
+		auto testVar = foo.sort!myComp;
+		genVar.should == testVar;
+	}
+
 	}c, sac);
 	stderr.writeln("Unittest for UnusedVariableCheck passed.");
 }


### PR DESCRIPTION
such as `a.should == b`