### PR TITLE
feat(highlight): support multiple themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ To avoid these cases, it's possible to pass the "--skipTests" option.
 #### Configuration
 By default all checks are enabled. Individual checks can be enabled or disabled
 by using a configuration file. Such a file can be placed, for example, is the root directory of your project.
-Running ```dscanner --defaultConfig``` will generate a default configuration file and print the file's location.
+Running `dscanner --defaultConfig` will generate a default configuration file and print the file's location.
 You can also specify the path to a configuration file by using the "--config" option if
 you want to override the default or the local settings.
 
@@ -306,8 +306,15 @@ and case tokens in the file.
 
 ### Syntax Highlighting
 The "--highlight" option prints the given source file as syntax-highlighted HTML
-to the standard output. The CSS styling is currently hard-coded to use the
-[Solarized](http://ethanschoonover.com/solarized) color scheme.
+to the standard output. The CSS styling uses the [Solarized](http://ethanschoonover.com/solarized)
+color scheme by default, but can be customised using the "--theme" option.
+
+The following themes are available:
+
+- `solarized`
+- `solarized-dark`
+- `gruvbox`
+- `gruvbox-dark`
 
 	No example. It would take up too much space
 

--- a/src/dscanner/highlighter.d
+++ b/src/dscanner/highlighter.d
@@ -10,8 +10,10 @@ import std.array;
 import dparse.lexer;
 
 // http://ethanschoonover.com/solarized
-void highlight(R)(ref R tokens, string fileName)
+void highlight(R)(ref R tokens, string fileName, string themeName)
 {
+	immutable(Theme)* theme = getTheme(themeName);
+
 	stdout.writeln(q"[
 <!DOCTYPE html>
 <html>
@@ -20,17 +22,19 @@ void highlight(R)(ref R tokens, string fileName)
 	stdout.writeln("<title>", fileName, "</title>");
 	stdout.writeln(q"[</head>
 <body>
-<style type="text/css">
-html  { background-color: #fdf6e3; color: #002b36; }
-.kwrd { color: #b58900; font-weight: bold;  }
-.com  { color: #93a1a1; font-style: italic; }
-.num  { color: #dc322f; font-weight: bold;  }
-.str  { color: #2aa198; font-style: italic; }
-.op   { color: #586e75; font-weight: bold;  }
-.type { color: #268bd2; font-weight: bold;  }
-.cons { color: #859900; font-weight: bold;  }
+<style type="text/css">]");
+	stdout.writefln("
+html  { background-color: %s; color: %s; }
+.kwrd { color: %s; font-weight: bold;  }
+.com  { color: %s; font-style: italic; }
+.num  { color: %s; font-weight: bold;  }
+.str  { color: %s; font-style: italic; }
+.op   { color: %s; font-weight: bold;  }
+.type { color: %s; font-weight: bold;  }
+.cons { color: %s; font-weight: bold;  }
 </style>
-<pre>]");
+<pre>", theme.bg, theme.fg, theme.kwrd, theme.com, theme.num, theme.str,
+			theme.op, theme.type, theme.cons);
 
 	while (!tokens.empty)
 	{
@@ -75,4 +79,38 @@ void writeSpan(string cssClass, string value)
 	else
 		stdout.write(`<span class="`, cssClass, `">`, value.replace("&",
 				"&amp;").replace("<", "&lt;"), `</span>`);
+}
+
+struct Theme
+{
+	string bg;
+	string fg;
+	string kwrd;
+	string com;
+	string num;
+	string str;
+	string op;
+	string type;
+	string cons;
+}
+
+immutable(Theme)* getTheme(string themeName)
+{
+	immutable Theme[string] themes = [
+		"solarized": Theme("#fdf6e3", "#002b36", "#b58900", "#93a1a1", "#dc322f", "#2aa198", "#586e75",
+				"#268bd2", "#859900"),
+		"solarized-dark": Theme("#002b36", "#fdf6e3", "#b58900", "#586e75", "#dc322f", "#2aa198",
+				"#93a1a1", "#268bd2", "#859900"),
+		"gruvbox": Theme("#fbf1c7", "#282828", "#b57614", "#a89984", "#9d0006", "#427b58",
+				"#504945", "#076678", "#79740e"),
+		"gruvbox-dark": Theme("#282828", "#fbf1c7", "#d79921", "#7c6f64",
+				"#cc241d", "#689d6a", "#a89984", "#458588", "#98971a")
+	];
+
+	immutable(Theme)* theme = themeName in themes;
+	// Default theme
+	if (theme is null)
+		theme = &themes["solarized"];
+
+	return theme;
 }

--- a/src/dscanner/main.d
+++ b/src/dscanner/main.d
@@ -64,6 +64,7 @@ else
 	bool report;
 	bool skipTests;
 	bool applySingleFixes;
+	string theme;
 	string resolveMessage;
 	string reportFormat;
 	string reportFile;
@@ -81,6 +82,7 @@ else
 		getopt(args, std.getopt.config.caseSensitive,
 				"sloc|l", &sloc,
 				"highlight", &highlight,
+				"theme", &theme,
 				"ctags|c", &ctags,
 				"help|h", &help,
 				"etags|e", &etags,
@@ -253,7 +255,7 @@ else
 		if (highlight)
 		{
 			auto tokens = byToken(bytes, config, &cache);
-			dscanner.highlighter.highlight(tokens, args.length == 1 ? "stdin" : args[1]);
+			dscanner.highlighter.highlight(tokens, args.length == 1 ? "stdin" : args[1], theme);
 			return 0;
 		}
 		else if (tokenDump)


### PR DESCRIPTION
Fixes #924 

Implementing this led me to discover a bug, although I don't know if it has already been reported - initialising AAs with inlined structs will not parse:
```
immutable Theme[string] themes = [ "gruvbox": { "#000000", "#ffffff", ... } ];
```
This errors out during lexing, with a pretty long list of errors.