### PR TITLE
Allow skipping checks with @("nolint(...)") and @nolint("...")

### DIFF
--- a/src/dscanner/analysis/base.d
+++ b/src/dscanner/analysis/base.d
@@ -411,13 +411,17 @@ public:
 	*
 	* When overriden, make sure to keep this structure
 	*/
-	override void visit(const(ModuleDeclaration) moduleDeclaration)
+	override void visit(const(Module) mod)
 	{
-		auto currNoLint = NoLintFactory.fromModuleDeclaration(moduleDeclaration);
-		noLint.push(currNoLint);
-		scope(exit) noLint.pop(currNoLint);
-
-		moduleDeclaration.accept(this);
+		if(mod.moduleDeclaration !is null)
+		{
+			auto currNoLint = NoLintFactory.fromModuleDeclaration(mod.moduleDeclaration);
+			noLint.push(currNoLint);
+			scope(exit) noLint.pop(currNoLint);
+			mod.accept(this);
+		}
+		else
+			mod.accept(this);
 	}
 
 	/**

--- a/src/dscanner/analysis/base.d
+++ b/src/dscanner/analysis/base.d
@@ -413,13 +413,15 @@ public:
 	*/
 	override void visit(const(Module) mod)
 	{
-		if(mod.moduleDeclaration !is null)
+		if (mod.moduleDeclaration !is null)
 		{
-		with(noLint.push(NoLintFactory.fromModuleDeclaration(mod.moduleDeclaration)))
+			with (noLint.push(NoLintFactory.fromModuleDeclaration(mod.moduleDeclaration)))
 				mod.accept(this);
 		}
 		else
+		{
 			mod.accept(this);
+		}
 	}
 
 	/**
@@ -429,7 +431,7 @@ public:
 	*/
 	override void visit(const(Declaration) decl)
 	{
-		with(noLint.push(NoLintFactory.fromDeclaration(decl)))
+		with (noLint.push(NoLintFactory.fromDeclaration(decl)))
 			decl.accept(this);
 	}
 
@@ -466,42 +468,42 @@ protected:
 	deprecated("Use the overload taking start and end locations or a Node instead")
 	void addErrorMessage(size_t line, size_t column, string key, string message)
 	{
-		if(noLint.containsCheck(key))
+		if (noLint.containsCheck(key))
 			return;
 		_messages.insert(Message(fileName, line, column, key, message, getName()));
 	}
 
 	void addErrorMessage(const BaseNode node, string key, string message, AutoFix[] autofixes = null)
 	{
-		if(noLint.containsCheck(key))
+		if (noLint.containsCheck(key))
 			return;
 		addErrorMessage(Message.Diagnostic.from(fileName, node, message), key, autofixes);
 	}
 
 	void addErrorMessage(const Token token, string key, string message, AutoFix[] autofixes = null)
 	{
-		if(noLint.containsCheck(key))
+		if (noLint.containsCheck(key))
 			return;
 		addErrorMessage(Message.Diagnostic.from(fileName, token, message), key, autofixes);
 	}
 
 	void addErrorMessage(const Token[] tokens, string key, string message, AutoFix[] autofixes = null)
 	{
-		if(noLint.containsCheck(key))
+		if (noLint.containsCheck(key))
 			return;
 		addErrorMessage(Message.Diagnostic.from(fileName, tokens, message), key, autofixes);
 	}
 
 	void addErrorMessage(size_t[2] index, size_t line, size_t[2] columns, string key, string message, AutoFix[] autofixes = null)
 	{
-		if(noLint.containsCheck(key))
+		if (noLint.containsCheck(key))
 			return;
 		addErrorMessage(index, [line, line], columns, key, message, autofixes);
 	}
 
 	void addErrorMessage(size_t[2] index, size_t[2] lines, size_t[2] columns, string key, string message, AutoFix[] autofixes = null)
 	{
-		if(noLint.containsCheck(key))
+		if (noLint.containsCheck(key))
 			return;
 		auto d = Message.Diagnostic.from(fileName, index, lines, columns, message);
 		_messages.insert(Message(d, key, getName(), autofixes));
@@ -509,14 +511,14 @@ protected:
 
 	void addErrorMessage(Message.Diagnostic diagnostic, string key, AutoFix[] autofixes = null)
 	{
-		if(noLint.containsCheck(key))
+		if (noLint.containsCheck(key))
 			return;
 		_messages.insert(Message(diagnostic, key, getName(), autofixes));
 	}
 
 	void addErrorMessage(Message.Diagnostic diagnostic, Message.Diagnostic[] supplemental, string key, AutoFix[] autofixes = null)
 	{
-		if(noLint.containsCheck(key))
+		if (noLint.containsCheck(key))
 			return;
 		_messages.insert(Message(diagnostic, supplemental, key, getName(), autofixes));
 	}
@@ -801,7 +803,7 @@ unittest
 	testScopes(q{
 		auto isNewScope = void;
 		auto depth = 1;
-		
+
 		void foo() {
 			isNewScope();
 			isOldScope();

--- a/src/dscanner/analysis/base.d
+++ b/src/dscanner/analysis/base.d
@@ -374,18 +374,14 @@ mixin template AnalyzerInfo(string checkName)
 
 auto isNoLintUDAForCurrentCheck(in string udaContent, in string check)
 {
-	import std.algorithm: map;
-	import std.ascii: toUpper;
-	import std.conv: to;
-
-	auto re = regex(`\w+`, "gi");
+	auto re = regex(`\w+`, "g");
 	auto matches = matchAll(udaContent, re);
 
 	if(!matches)
 		return false;
 
 	const udaName = matches.hit;
-	if(udaName.map!(c => c.toUpper).to!string != "NOLINT")
+	if(udaName != "nolint")
 		return false;
 
 	matches.popFront;
@@ -403,11 +399,10 @@ auto isNoLintUDAForCurrentCheck(in string udaContent, in string check)
 
 unittest
 {
-	const s1 = "NOLINT(abc)";
-	const s2 = "NOLINT(abc, efg, hij)";
-	const s3 = "nolint(abc)";
-	const s4 = "    NOLINT   (   abc ,  efg  )    ";
-	const s5 = "OtherUda(abc)";
+	const s1 = "nolint(abc)";
+	const s2 = "nolint(abc, efg, hij)";
+	const s3 = "    nolint (   abc ,  efg  )    ";
+	const s4 = "OtherUda(abc)";
 
 	assert(isNoLintUDAForCurrentCheck(s1, "abc"));
 	assert(!isNoLintUDAForCurrentCheck(s1, "efg"));
@@ -418,13 +413,10 @@ unittest
 	assert(!isNoLintUDAForCurrentCheck(s2, "kel"));
 
 	assert(isNoLintUDAForCurrentCheck(s3, "abc"));
-	assert(!isNoLintUDAForCurrentCheck(s3, "efg"));
+	assert(isNoLintUDAForCurrentCheck(s3, "efg"));
+	assert(!isNoLintUDAForCurrentCheck(s3, "hij"));
 
-	assert(isNoLintUDAForCurrentCheck(s4, "abc"));
-	assert(isNoLintUDAForCurrentCheck(s4, "efg"));
-	assert(!isNoLintUDAForCurrentCheck(s4, "hij"));
-
-	assert(!isNoLintUDAForCurrentCheck(s5, "abc"));
+	assert(!isNoLintUDAForCurrentCheck(s4, "abc"));
 }
 
 
@@ -577,7 +569,7 @@ protected:
 		return this.errorMsgDisabled == 0;
 	}
 
-	// Disable error message if declaration contains UDA : @("NOLINT(..)")
+	// Disable error message if declaration contains UDA : @("nolint(..)")
 	// that indicates to skip linting on this declaration
 	// Return wheter the message is actually disabled or not
 	bool maybeDisableErrorMessage(const Declaration decl)

--- a/src/dscanner/analysis/base.d
+++ b/src/dscanner/analysis/base.d
@@ -405,6 +405,21 @@ public:
 			unittest_.accept(this);
 	}
 
+	/**
+	* Visits a declaration.
+	*
+	* When overriden, make sure to disable and reenable error messages
+	*/
+	override void visit(const(Declaration) decl)
+	{
+		const msgDisabled = maybeDisableErrorMessage(decl);
+
+		decl.accept(this);
+
+		if(msgDisabled)
+			reenableErrorMessage();
+	}
+
 	AutoFix.CodeReplacement[] resolveAutoFix(
 		const Module mod,
 		scope const(Token)[] tokens,

--- a/src/dscanner/analysis/base.d
+++ b/src/dscanner/analysis/base.d
@@ -415,10 +415,8 @@ public:
 	{
 		if(mod.moduleDeclaration !is null)
 		{
-			auto currNoLint = NoLintFactory.fromModuleDeclaration(mod.moduleDeclaration);
-			noLint.push(currNoLint);
-			scope(exit) noLint.pop(currNoLint);
-			mod.accept(this);
+		with(noLint.push(NoLintFactory.fromModuleDeclaration(mod.moduleDeclaration)))
+				mod.accept(this);
 		}
 		else
 			mod.accept(this);
@@ -431,11 +429,8 @@ public:
 	*/
 	override void visit(const(Declaration) decl)
 	{
-		auto currNoLint = NoLintFactory.fromDeclaration(decl);
-		noLint.push(currNoLint);
-		scope(exit) noLint.pop(currNoLint);
-
-		decl.accept(this);
+		with(noLint.push(NoLintFactory.fromDeclaration(decl)))
+			decl.accept(this);
 	}
 
 	AutoFix.CodeReplacement[] resolveAutoFix(

--- a/src/dscanner/analysis/base.d
+++ b/src/dscanner/analysis/base.d
@@ -467,42 +467,42 @@ protected:
 	deprecated("Use the overload taking start and end locations or a Node instead")
 	void addErrorMessage(size_t line, size_t column, string key, string message)
 	{
-		if(noLint.containsCheck(this.getName()))
+		if(noLint.containsCheck(key))
 			return;
 		_messages.insert(Message(fileName, line, column, key, message, getName()));
 	}
 
 	void addErrorMessage(const BaseNode node, string key, string message, AutoFix[] autofixes = null)
 	{
-		if(noLint.containsCheck(this.getName()))
+		if(noLint.containsCheck(key))
 			return;
 		addErrorMessage(Message.Diagnostic.from(fileName, node, message), key, autofixes);
 	}
 
 	void addErrorMessage(const Token token, string key, string message, AutoFix[] autofixes = null)
 	{
-		if(noLint.containsCheck(this.getName()))
+		if(noLint.containsCheck(key))
 			return;
 		addErrorMessage(Message.Diagnostic.from(fileName, token, message), key, autofixes);
 	}
 
 	void addErrorMessage(const Token[] tokens, string key, string message, AutoFix[] autofixes = null)
 	{
-		if(noLint.containsCheck(this.getName()))
+		if(noLint.containsCheck(key))
 			return;
 		addErrorMessage(Message.Diagnostic.from(fileName, tokens, message), key, autofixes);
 	}
 
 	void addErrorMessage(size_t[2] index, size_t line, size_t[2] columns, string key, string message, AutoFix[] autofixes = null)
 	{
-		if(noLint.containsCheck(this.getName()))
+		if(noLint.containsCheck(key))
 			return;
 		addErrorMessage(index, [line, line], columns, key, message, autofixes);
 	}
 
 	void addErrorMessage(size_t[2] index, size_t[2] lines, size_t[2] columns, string key, string message, AutoFix[] autofixes = null)
 	{
-		if(noLint.containsCheck(this.getName()))
+		if(noLint.containsCheck(key))
 			return;
 		auto d = Message.Diagnostic.from(fileName, index, lines, columns, message);
 		_messages.insert(Message(d, key, getName(), autofixes));
@@ -510,14 +510,14 @@ protected:
 
 	void addErrorMessage(Message.Diagnostic diagnostic, string key, AutoFix[] autofixes = null)
 	{
-		if(noLint.containsCheck(this.getName()))
+		if(noLint.containsCheck(key))
 			return;
 		_messages.insert(Message(diagnostic, key, getName(), autofixes));
 	}
 
 	void addErrorMessage(Message.Diagnostic diagnostic, Message.Diagnostic[] supplemental, string key, AutoFix[] autofixes = null)
 	{
-		if(noLint.containsCheck(this.getName()))
+		if(noLint.containsCheck(key))
 			return;
 		_messages.insert(Message(diagnostic, supplemental, key, getName(), autofixes));
 	}

--- a/src/dscanner/analysis/nolint.d
+++ b/src/dscanner/analysis/nolint.d
@@ -178,7 +178,7 @@ private:
 	// into a NoLint struct
 	static Nullable!NoLint fromString(in string str)
 	{
-		auto re = regex(`\w+`, "g");
+		auto re = regex(`[\w-_.]+`, "g");
 		auto matches = matchAll(str, re);
 
 		if(!matches)
@@ -212,7 +212,8 @@ unittest
 	const s1 = "nolint(abc)";
 	const s2 = "nolint(abc, efg, hij)";
 	const s3 = "    nolint (   abc ,  efg  )    ";
-	const s4 = "OtherUda(abc)";
+	const s4 = "nolint(dscanner.style.abc_efg-ijh)";
+	const s5 = "OtherUda(abc)";
 
 	assert(NoLintFactory.fromString(s1).get.containsCheck("abc"));
 
@@ -223,5 +224,10 @@ unittest
 	assert(NoLintFactory.fromString(s3).get.containsCheck("abc"));
 	assert(NoLintFactory.fromString(s3).get.containsCheck("efg"));
 
-	assert(NoLintFactory.fromString(s4).isNull);
+	assert(NoLintFactory.fromString(s4).get.containsCheck("dscanner.style.abc_efg-ijh"));
+
+	assert(NoLintFactory.fromString(s5).isNull);
+
+	import std.stdio: stderr, writeln;
+	stderr.writeln("Unittest for NoLint passed.");
 }

--- a/src/dscanner/analysis/nolint.d
+++ b/src/dscanner/analysis/nolint.d
@@ -39,6 +39,19 @@ private:
 
 struct NoLintFactory
 {
+	static Nullable!NoLint fromModuleDeclaration(in ModuleDeclaration moduleDeclaration)
+	{
+		NoLint noLint;
+
+		foreach(atAttribute; moduleDeclaration.atAttributes)
+			noLint.merge(NoLintFactory.fromAtAttribute(atAttribute));
+
+		if(!noLint.getDisabledChecks.length)
+			return nullNoLint;
+
+		return noLint.nullable;
+	}
+
 	static Nullable!NoLint fromDeclaration(in Declaration declaration)
 	{
 		NoLint noLint;

--- a/src/dscanner/analysis/nolint.d
+++ b/src/dscanner/analysis/nolint.d
@@ -1,0 +1,189 @@
+module dscanner.analysis.nolint;
+
+import dparse.ast;
+import dparse.lexer;
+
+import std.algorithm: canFind;
+import std.regex: regex, matchAll;
+import std.string: strip;
+import std.typecons;
+
+
+struct NoLint
+{
+	bool containsCheck(in string check) const
+	{
+		return disabledChecks.canFind(check);
+	}
+
+package:
+	const(string[]) getDisabledChecks() const
+	{
+		return this.disabledChecks;
+	}
+
+	void addCheck(in string check)
+	{
+		disabledChecks ~= check;
+	}
+
+	void merge(in Nullable!NoLint other)
+	{
+		if(!other.isNull)
+			this.disabledChecks ~= other.get.getDisabledChecks();
+	}
+
+private:
+		string[] disabledChecks;
+}
+
+struct NoLintFactory
+{
+	static Nullable!NoLint fromDeclaration(in Declaration declaration)
+	{
+		NoLint noLint;
+		foreach(attribute; declaration.attributes)
+			noLint.merge(NoLintFactory.fromAttribute(attribute));
+
+		if(!noLint.getDisabledChecks.length)
+			return nullNoLint;
+
+		return noLint.nullable;
+	}
+
+
+private:
+	static Nullable!NoLint fromAttribute(const(Attribute) attribute)
+	{
+		if(attribute is null)
+			return nullNoLint;
+
+		return NoLintFactory.fromAtAttribute(attribute.atAttribute);
+
+	}
+
+	static Nullable!NoLint fromAtAttribute(const(AtAttribute) atAttribute)
+	{
+		if(atAttribute is null)
+			return nullNoLint;
+
+		auto ident = atAttribute.identifier;
+		auto argumentList = atAttribute.argumentList;
+
+		if(argumentList !is null)
+		{
+			if(ident.text.length)
+				return NoLintFactory.fromStructUda(ident, argumentList);
+			else
+				return NoLintFactory.fromStringUda(argumentList);
+
+		}
+		else
+			return nullNoLint;
+	}
+
+	// @nolint("..")
+	static Nullable!NoLint fromStructUda(in Token ident, in ArgumentList argumentList)
+	in(ident.text.length && argumentList !is null)
+	{
+		if(ident.text != "nolint")
+			return nullNoLint;
+
+		NoLint noLint;
+
+		foreach(nodeExpr; argumentList.items)
+		{
+			if(auto unaryExpr = cast(UnaryExpression) nodeExpr)
+			{
+				auto primaryExpression = unaryExpr.primaryExpression;
+				if(primaryExpression is null)
+					continue;
+
+				if(primaryExpression.primary != tok!"stringLiteral")
+					continue;
+
+				noLint.addCheck(primaryExpression.primary.text.strip("\""));
+			}
+		}
+
+		if(!noLint.getDisabledChecks().length)
+			return nullNoLint;
+
+		return noLint.nullable;
+	}
+
+	// @("nolint(..)")
+	static Nullable!NoLint fromStringUda(in ArgumentList argumentList)
+	in(argumentList !is null)
+	{
+		NoLint noLint;
+
+		foreach(nodeExpr; argumentList.items)
+		{
+			if(auto unaryExpr = cast(UnaryExpression) nodeExpr)
+			{
+				auto primaryExpression = unaryExpr.primaryExpression;
+				if(primaryExpression is null)
+					continue;
+
+				if(primaryExpression.primary != tok!"stringLiteral")
+					continue;
+
+				auto str = primaryExpression.primary.text.strip("\"");
+				Nullable!NoLint currNoLint = NoLintFactory.fromString(str);
+				noLint.merge(currNoLint);
+			}
+		}
+
+		if(!noLint.getDisabledChecks().length)
+			return nullNoLint;
+
+		return noLint.nullable;
+
+	}
+
+	// Transform a string with form "nolint(abc, efg)"
+	// into a NoLint struct
+	static Nullable!NoLint fromString(in string str)
+	{
+		auto re = regex(`\w+`, "g");
+		auto matches = matchAll(str, re);
+
+		if(!matches)
+			return nullNoLint;
+
+		const udaName = matches.hit;
+		if(udaName != "nolint")
+			return nullNoLint;
+
+		matches.popFront;
+
+		NoLint noLint;
+
+		while(matches)
+		{
+			noLint.addCheck(matches.hit);
+			matches.popFront;
+		}
+
+		if(!noLint.getDisabledChecks.length)
+			return nullNoLint;
+
+		return noLint.nullable;
+	}
+
+	static nullNoLint = Nullable!NoLint.init;
+}
+
+unittest
+{
+	const s1 = "nolint(abc)";
+	const s2 = "nolint(abc, efg, hij)";
+	const s3 = "    nolint (   abc ,  efg  )    ";
+	const s4 = "OtherUda(abc)";
+
+	assert(NoLintFactory.fromString(s1).get == NoLint(["abc"]));
+	assert(NoLintFactory.fromString(s2).get == NoLint(["abc", "efg", "hij"]));
+	assert(NoLintFactory.fromString(s3).get == NoLint(["abc", "efg"]));
+	assert(NoLintFactory.fromString(s4).isNull);
+}

--- a/src/dscanner/analysis/style.d
+++ b/src/dscanner/analysis/style.d
@@ -238,7 +238,7 @@ unittest
 	}c, sac);
 
 	assertAnalyzerWarnings(q{
-		@("nolint(style_check)")
+		@("nolint(dscanner.style.phobos_naming_convention)")
 		module AMODULE;
 	}c, sac);
 

--- a/src/dscanner/analysis/style.d
+++ b/src/dscanner/analysis/style.d
@@ -14,6 +14,7 @@ import std.conv;
 import std.format;
 import dscanner.analysis.helpers;
 import dscanner.analysis.base;
+import dscanner.analysis.nolint;
 import dsymbol.scope_ : Scope;
 
 final class StyleChecker : BaseAnalyzer
@@ -33,8 +34,9 @@ final class StyleChecker : BaseAnalyzer
 
 	override void visit(const ModuleDeclaration dec)
 	{
-		if(stopLinting(dec))
-			return;
+		auto currNoLint = NoLintFactory.fromModuleDeclaration(dec);
+		noLint.push(currNoLint);
+		scope(exit) noLint.pop(currNoLint);
 
 		foreach (part; dec.moduleName.identifiers)
 		{

--- a/src/dscanner/analysis/style.d
+++ b/src/dscanner/analysis/style.d
@@ -33,6 +33,9 @@ final class StyleChecker : BaseAnalyzer
 
 	override void visit(const ModuleDeclaration dec)
 	{
+		if(stopLinting(dec))
+			return;
+
 		foreach (part; dec.moduleName.identifiers)
 		{
 			if (part.text.matchFirst(moduleNameRegex).length == 0)
@@ -230,6 +233,11 @@ unittest
 		extern(Windows):
 			bool WinButWithBody(){} /+
 			     ^^^^^^^^^^^^^^ [warn]: Function name 'WinButWithBody' does not match style guidelines. +/
+	}c, sac);
+
+	assertAnalyzerWarnings(q{
+		@("nolint(style_check)")
+		module AMODULE;
 	}c, sac);
 
 	stderr.writeln("Unittest for StyleChecker passed.");

--- a/src/dscanner/analysis/style.d
+++ b/src/dscanner/analysis/style.d
@@ -34,7 +34,7 @@ final class StyleChecker : BaseAnalyzer
 
 	override void visit(const ModuleDeclaration dec)
 	{
-		with(noLint.push(NoLintFactory.fromModuleDeclaration(dec)))
+		with (noLint.push(NoLintFactory.fromModuleDeclaration(dec)))
 			dec.accept(this);
 
 		foreach (part; dec.moduleName.identifiers)

--- a/src/dscanner/analysis/style.d
+++ b/src/dscanner/analysis/style.d
@@ -34,9 +34,8 @@ final class StyleChecker : BaseAnalyzer
 
 	override void visit(const ModuleDeclaration dec)
 	{
-		auto currNoLint = NoLintFactory.fromModuleDeclaration(dec);
-		noLint.push(currNoLint);
-		scope(exit) noLint.pop(currNoLint);
+		with(noLint.push(NoLintFactory.fromModuleDeclaration(dec)))
+			dec.accept(this);
 
 		foreach (part; dec.moduleName.identifiers)
 		{

--- a/src/dscanner/analysis/style.d
+++ b/src/dscanner/analysis/style.d
@@ -237,10 +237,5 @@ unittest
 			     ^^^^^^^^^^^^^^ [warn]: Function name 'WinButWithBody' does not match style guidelines. +/
 	}c, sac);
 
-	assertAnalyzerWarnings(q{
-		@("nolint(dscanner.style.phobos_naming_convention)")
-		module AMODULE;
-	}c, sac);
-
 	stderr.writeln("Unittest for StyleChecker passed.");
 }

--- a/src/dscanner/analysis/useless_initializer.d
+++ b/src/dscanner/analysis/useless_initializer.d
@@ -94,7 +94,7 @@ public:
 	{
 		_inStruct.insert(decl.structDeclaration !is null);
 
-		with(noLint.push(NoLintFactory.fromDeclaration(decl)))
+		with (noLint.push(NoLintFactory.fromDeclaration(decl)))
 			decl.accept(this);
 
 		if (_inStruct.length > 1 && _inStruct[$-2] && decl.constructor &&

--- a/src/dscanner/analysis/useless_initializer.d
+++ b/src/dscanner/analysis/useless_initializer.d
@@ -370,12 +370,12 @@ public:
 
 	// passes
 	assertAnalyzerWarnings(q{
-    	  	@("NOLINT(useless_initializer)")
+			@("nolint(useless_initializer)")
 			int a = 0;
 		    ubyte a = 0x0;      /+
 		              ^^^ [warn]: X +/
 
-    	  	@("NOLINT(useless_initializer)")
+			@("nolint(useless_initializer)")
 			int f() {
 				int a = 0;
 			}

--- a/src/dscanner/analysis/useless_initializer.d
+++ b/src/dscanner/analysis/useless_initializer.d
@@ -372,8 +372,8 @@ public:
 	assertAnalyzerWarnings(q{
 			@("nolint(useless_initializer)")
 			int a = 0;
-		    ubyte a = 0x0;      /+
-		              ^^^ [warn]: X +/
+      int a = 0;      /+
+              ^ [warn]: X +/
 
 			@("nolint(useless_initializer)")
 			int f() {
@@ -384,8 +384,15 @@ public:
 
 			@nolint("useless_initializer")
 			int a = 0;
-		    ubyte a = 0x0;      /+
-		              ^^^ [warn]: X +/
+      int a = 0;      /+
+              ^ [warn]: X +/
+
+			@("nolint(other_check, useless_initializer, another_one)")
+			int a = 0;
+
+			@nolint("other_check", "another_one", "useless_initializer")
+			int a = 0;
+
 	}, sac);
 
 	stderr.writeln("Unittest for UselessInitializerChecker passed.");

--- a/src/dscanner/analysis/useless_initializer.d
+++ b/src/dscanner/analysis/useless_initializer.d
@@ -5,6 +5,7 @@
 module dscanner.analysis.useless_initializer;
 
 import dscanner.analysis.base;
+import dscanner.analysis.nolint;
 import dscanner.utils : safeAccess;
 import containers.dynamicarray;
 import containers.hashmap;
@@ -93,12 +94,11 @@ public:
 	{
 		_inStruct.insert(decl.structDeclaration !is null);
 
-		const msgDisabled = maybeDisableErrorMessage(decl);
+		auto currNoLint = NoLintFactory.fromDeclaration(decl);
+		noLint.push(currNoLint);
+		scope(exit) noLint.pop(currNoLint);
 
 		decl.accept(this);
-
-		if(msgDisabled)
-			reenableErrorMessage();
 
 		if (_inStruct.length > 1 && _inStruct[$-2] && decl.constructor &&
 			((decl.constructor.parameters && decl.constructor.parameters.parameters.length == 0) ||

--- a/src/dscanner/analysis/useless_initializer.d
+++ b/src/dscanner/analysis/useless_initializer.d
@@ -93,17 +93,7 @@ public:
 	{
 		_inStruct.insert(decl.structDeclaration !is null);
 
-		const msgDisabled = () {
-			foreach(attr; decl.attributes)
-			{
-				if(this.isCheckDisabled(attr))
-				{
-					disableErrorMessage();
-					return true;
-				}
-			}
-			return false;
-		}();
+		const msgDisabled = maybeDisableErrorMessage(decl);
 
 		decl.accept(this);
 

--- a/src/dscanner/analysis/useless_initializer.d
+++ b/src/dscanner/analysis/useless_initializer.d
@@ -370,28 +370,28 @@ public:
 
 	// passes
 	assertAnalyzerWarnings(q{
-			@("nolint(useless_initializer)")
+		@("nolint(dscanner.useless-initializer)")
+		int a = 0;
+		int a = 0;          /+
+		        ^ [warn]: X +/
+
+		@("nolint(dscanner.useless-initializer)")
+		int f() {
 			int a = 0;
-      int a = 0;      /+
-              ^ [warn]: X +/
+		}
 
-			@("nolint(useless_initializer)")
-			int f() {
-				int a = 0;
-			}
+		struct nolint { string s; }
 
-			struct nolint { string s; }
+		@nolint("dscanner.useless-initializer")
+		int a = 0;
+		int a = 0;          /+
+		        ^ [warn]: X +/
 
-			@nolint("useless_initializer")
-			int a = 0;
-      int a = 0;      /+
-              ^ [warn]: X +/
+		@("nolint(other_check, dscanner.useless-initializer, another_one)")
+		int a = 0;
 
-			@("nolint(other_check, useless_initializer, another_one)")
-			int a = 0;
-
-			@nolint("other_check", "another_one", "useless_initializer")
-			int a = 0;
+		@nolint("other_check", "another_one", "dscanner.useless-initializer")
+		int a = 0;
 
 	}, sac);
 

--- a/src/dscanner/analysis/useless_initializer.d
+++ b/src/dscanner/analysis/useless_initializer.d
@@ -92,7 +92,24 @@ public:
 	override void visit(const(Declaration) decl)
 	{
 		_inStruct.insert(decl.structDeclaration !is null);
+
+		const msgDisabled = () {
+			foreach(attr; decl.attributes)
+			{
+				if(this.isCheckDisabled(attr))
+				{
+					disableErrorMessage();
+					return true;
+				}
+			}
+			return false;
+		}();
+
 		decl.accept(this);
+
+		if(msgDisabled)
+			reenableErrorMessage();
+
 		if (_inStruct.length > 1 && _inStruct[$-2] && decl.constructor &&
 			((decl.constructor.parameters && decl.constructor.parameters.parameters.length == 0) ||
 			!decl.constructor.parameters))

--- a/src/dscanner/analysis/useless_initializer.d
+++ b/src/dscanner/analysis/useless_initializer.d
@@ -395,6 +395,18 @@ public:
 
 	}, sac);
 
+	// passes (disable check at module level)
+	assertAnalyzerWarnings(q{
+		@("nolint(dscanner.useless-initializer)")
+		module my_module;
+
+		int a = 0;
+
+		int f() {
+			int a = 0;
+		}
+	}, sac);
+
 	stderr.writeln("Unittest for UselessInitializerChecker passed.");
 }
 

--- a/src/dscanner/analysis/useless_initializer.d
+++ b/src/dscanner/analysis/useless_initializer.d
@@ -379,6 +379,13 @@ public:
 			int f() {
 				int a = 0;
 			}
+
+			struct nolint { string s; }
+
+			@nolint("useless_initializer")
+			int a = 0;
+		    ubyte a = 0x0;      /+
+		              ^^^ [warn]: X +/
 	}, sac);
 
 	stderr.writeln("Unittest for UselessInitializerChecker passed.");

--- a/src/dscanner/analysis/useless_initializer.d
+++ b/src/dscanner/analysis/useless_initializer.d
@@ -368,6 +368,19 @@ public:
 		NotKnown nk = NotKnown.init;
 	}, sac);
 
+	// passes
+	assertAnalyzerWarnings(q{
+    	  	@("NOLINT(useless_initializer)")
+			int a = 0;
+		    ubyte a = 0x0;      /+
+		              ^^^ [warn]: X +/
+
+    	  	@("NOLINT(useless_initializer)")
+			int f() {
+				int a = 0;
+			}
+	}, sac);
+
 	stderr.writeln("Unittest for UselessInitializerChecker passed.");
 }
 

--- a/src/dscanner/analysis/useless_initializer.d
+++ b/src/dscanner/analysis/useless_initializer.d
@@ -94,11 +94,8 @@ public:
 	{
 		_inStruct.insert(decl.structDeclaration !is null);
 
-		auto currNoLint = NoLintFactory.fromDeclaration(decl);
-		noLint.push(currNoLint);
-		scope(exit) noLint.pop(currNoLint);
-
-		decl.accept(this);
+		with(noLint.push(NoLintFactory.fromDeclaration(decl)))
+			decl.accept(this);
 
 		if (_inStruct.length > 1 && _inStruct[$-2] && decl.constructor &&
 			((decl.constructor.parameters && decl.constructor.parameters.parameters.length == 0) ||


### PR DESCRIPTION
Related #935 

Here is the basic idea I had in mind to locally disable checks : one can attach a user defined attribute to any declaration (function declaration, variable declaration, ..). If this happens, the given check is disabled for the given declaration. 

Example : 
```
@("NOLINT(useless_initializer)")
int a = 0; // No warning emited
```

One could have done that with comment (like [clang-tidy](https://clang.llvm.org/extra/clang-tidy/#suppressing-undesired-diagnostics) does) but I think UDAs are great since they are directly included in AST. They have a limitation though : according to [libdparse D grammar](http://libdparse.dlang.io/grammar.html#declaration), attributes can only be paired with 'declaration2'. So this would be a little hard to disable checks at other levels than declaration. For example, delete_check is applied on a deleteExpression.

Looking forward your reviews, I will try yo extend this proof of concept to all warnings in next few days if you're are okay with this direction.