### PR TITLE
add BaseAnalyzerArguments to keep ctor changes sane

### DIFF
--- a/src/dscanner/analysis/alias_syntax_check.d
+++ b/src/dscanner/analysis/alias_syntax_check.d
@@ -18,9 +18,9 @@ final class AliasSyntaxCheck : BaseAnalyzer
 
 	mixin AnalyzerInfo!"alias_syntax_check";
 
-	this(string fileName, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, null, skipTests);
+		super(args);
 	}
 
 	override void visit(const AliasDeclaration ad)

--- a/src/dscanner/analysis/allman.d
+++ b/src/dscanner/analysis/allman.d
@@ -30,9 +30,9 @@ final class AllManCheck : BaseAnalyzer
 	mixin AnalyzerInfo!"allman_braces_check";
 
 	///
-	this(string fileName, const(Token)[] tokens, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, null, skipTests);
+		super(args);
 		foreach (i; 1 .. tokens.length - 1)
 		{
 			const curLine = tokens[i].line;

--- a/src/dscanner/analysis/always_curly.d
+++ b/src/dscanner/analysis/always_curly.d
@@ -21,9 +21,9 @@ final class AlwaysCurlyCheck : BaseAnalyzer
 	alias visit = BaseAnalyzer.visit;
 
 	///
-	this(string fileName, const(Token)[] tokens, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, null, skipTests);
+		super(args);
 	}
 
 	void test(L, B)(L loc, B s, string stmtKind)

--- a/src/dscanner/analysis/asm_style.d
+++ b/src/dscanner/analysis/asm_style.d
@@ -22,9 +22,9 @@ final class AsmStyleCheck : BaseAnalyzer
 
 	mixin AnalyzerInfo!"asm_style_check";
 
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const AsmBrExp brExp)

--- a/src/dscanner/analysis/assert_without_msg.d
+++ b/src/dscanner/analysis/assert_without_msg.d
@@ -23,9 +23,9 @@ final class AssertWithoutMessageCheck : BaseAnalyzer
 	mixin AnalyzerInfo!"assert_without_msg";
 
 	///
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const AssertExpression expr)

--- a/src/dscanner/analysis/auto_function.d
+++ b/src/dscanner/analysis/auto_function.d
@@ -40,9 +40,9 @@ public:
 	mixin AnalyzerInfo!"auto_function_check";
 
 	///
-	this(string fileName, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, null, skipTests);
+		super(args);
 	}
 
 	package static const(Token)[] findAutoReturnType(const(FunctionDeclaration) decl)

--- a/src/dscanner/analysis/auto_ref_assignment.d
+++ b/src/dscanner/analysis/auto_ref_assignment.d
@@ -17,9 +17,9 @@ final class AutoRefAssignmentCheck : BaseAnalyzer
 	mixin AnalyzerInfo!"auto_ref_assignment_check";
 
 	///
-	this(string fileName, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, null, skipTests);
+		super(args);
 	}
 
 	override void visit(const Module m)

--- a/src/dscanner/analysis/body_on_disabled_funcs.d
+++ b/src/dscanner/analysis/body_on_disabled_funcs.d
@@ -12,9 +12,9 @@ final class BodyOnDisabledFuncsCheck : BaseAnalyzer
 
 	mixin AnalyzerInfo!"body_on_disabled_func_check";
 
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	static foreach (AggregateType; AliasSeq!(InterfaceDeclaration, ClassDeclaration,

--- a/src/dscanner/analysis/builtin_property_names.d
+++ b/src/dscanner/analysis/builtin_property_names.d
@@ -33,9 +33,9 @@ final class BuiltinPropertyNameCheck : BaseAnalyzer
 
 	mixin AnalyzerInfo!"builtin_property_names_check";
 
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const FunctionDeclaration fd)

--- a/src/dscanner/analysis/comma_expression.d
+++ b/src/dscanner/analysis/comma_expression.d
@@ -19,9 +19,9 @@ final class CommaExpressionCheck : BaseAnalyzer
 
 	mixin AnalyzerInfo!"comma_expression_check";
 
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const Expression ex)

--- a/src/dscanner/analysis/constructors.d
+++ b/src/dscanner/analysis/constructors.d
@@ -14,9 +14,9 @@ final class ConstructorCheck : BaseAnalyzer
 
 	mixin AnalyzerInfo!"constructor_check";
 
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const ClassDeclaration classDeclaration)

--- a/src/dscanner/analysis/cyclomatic_complexity.d
+++ b/src/dscanner/analysis/cyclomatic_complexity.d
@@ -53,10 +53,9 @@ final class CyclomaticComplexityCheck : BaseAnalyzer
 	int maxCyclomaticComplexity;
 
 	///
-	this(string fileName, const(Scope)* sc, bool skipTests = false,
-		int maxCyclomaticComplexity = 50)
+	this(BaseAnalyzerArguments args, int maxCyclomaticComplexity = 50)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 		this.maxCyclomaticComplexity = maxCyclomaticComplexity;
 	}
 

--- a/src/dscanner/analysis/del.d
+++ b/src/dscanner/analysis/del.d
@@ -20,9 +20,9 @@ final class DeleteCheck : BaseAnalyzer
 
 	mixin AnalyzerInfo!"delete_check";
 
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const DeleteExpression d)

--- a/src/dscanner/analysis/duplicate_attribute.d
+++ b/src/dscanner/analysis/duplicate_attribute.d
@@ -23,9 +23,9 @@ final class DuplicateAttributeCheck : BaseAnalyzer
 
 	mixin AnalyzerInfo!"duplicate_attribute";
 
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const Declaration node)

--- a/src/dscanner/analysis/enumarrayliteral.d
+++ b/src/dscanner/analysis/enumarrayliteral.d
@@ -21,9 +21,9 @@ final class EnumArrayLiteralCheck : BaseAnalyzer
 
 	mixin AnalyzerInfo!"enum_array_literal_check";
 
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	bool looking;

--- a/src/dscanner/analysis/explicitly_annotated_unittests.d
+++ b/src/dscanner/analysis/explicitly_annotated_unittests.d
@@ -20,9 +20,9 @@ final class ExplicitlyAnnotatedUnittestCheck : BaseAnalyzer
     mixin AnalyzerInfo!"explicitly_annotated_unittests";
 
 	///
-	this(string fileName, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, null, skipTests);
+		super(args);
 	}
 
 	override void visit(const Declaration decl)

--- a/src/dscanner/analysis/final_attribute.d
+++ b/src/dscanner/analysis/final_attribute.d
@@ -74,9 +74,9 @@ public:
 	};
 
 	///
-	this(string fileName, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, null, skipTests);
+		super(args);
 	}
 
 	override void visit(const(StructDeclaration) sd)

--- a/src/dscanner/analysis/fish.d
+++ b/src/dscanner/analysis/fish.d
@@ -22,9 +22,9 @@ final class FloatOperatorCheck : BaseAnalyzer
 	enum string KEY = "dscanner.deprecated.floating_point_operators";
 	mixin AnalyzerInfo!"float_operator_check";
 
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const RelExpression r)

--- a/src/dscanner/analysis/function_attributes.d
+++ b/src/dscanner/analysis/function_attributes.d
@@ -28,9 +28,9 @@ final class FunctionAttributeCheck : BaseAnalyzer
 
 	mixin AnalyzerInfo!"function_attribute_check";
 
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const InterfaceDeclaration dec)

--- a/src/dscanner/analysis/has_public_example.d
+++ b/src/dscanner/analysis/has_public_example.d
@@ -22,9 +22,9 @@ final class HasPublicExampleCheck : BaseAnalyzer
 
 	mixin AnalyzerInfo!"has_public_example";
 
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const Module mod)

--- a/src/dscanner/analysis/if_constraints_indent.d
+++ b/src/dscanner/analysis/if_constraints_indent.d
@@ -20,9 +20,9 @@ final class IfConstraintsIndentCheck : BaseAnalyzer
 	mixin AnalyzerInfo!"if_constraints_indent";
 
 	///
-	this(string fileName, const(Token)[] tokens, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, null, skipTests);
+		super(args);
 
 		// convert tokens to a list of token starting positions per line
 

--- a/src/dscanner/analysis/if_statements.d
+++ b/src/dscanner/analysis/if_statements.d
@@ -16,9 +16,9 @@ final class IfStatementCheck : BaseAnalyzer
 	alias visit = BaseAnalyzer.visit;
 	mixin AnalyzerInfo!"redundant_if_check";
 
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const IfStatement ifStatement)

--- a/src/dscanner/analysis/ifelsesame.d
+++ b/src/dscanner/analysis/ifelsesame.d
@@ -26,9 +26,9 @@ final class IfElseSameCheck : BaseAnalyzer
 
 	mixin AnalyzerInfo!"if_else_same_check";
 
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const IfStatement ifStatement)

--- a/src/dscanner/analysis/imports_sortedness.d
+++ b/src/dscanner/analysis/imports_sortedness.d
@@ -20,9 +20,9 @@ final class ImportSortednessCheck : BaseAnalyzer
 	mixin AnalyzerInfo!"imports_sortedness";
 
 	///
-	this(string fileName, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, null, skipTests);
+		super(args);
 	}
 
 	mixin ScopedVisit!Module;

--- a/src/dscanner/analysis/incorrect_infinite_range.d
+++ b/src/dscanner/analysis/incorrect_infinite_range.d
@@ -22,9 +22,9 @@ final class IncorrectInfiniteRangeCheck : BaseAnalyzer
 	mixin AnalyzerInfo!"incorrect_infinite_range_check";
 
 	///
-	this(string fileName, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, null, skipTests);
+		super(args);
 	}
 
 	override void visit(const StructBody structBody)

--- a/src/dscanner/analysis/label_var_same_name_check.d
+++ b/src/dscanner/analysis/label_var_same_name_check.d
@@ -17,9 +17,9 @@ final class LabelVarNameCheck : ScopedBaseAnalyzer
 {
 	mixin AnalyzerInfo!"label_var_same_name_check";
 
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	mixin AggregateVisit!ClassDeclaration;

--- a/src/dscanner/analysis/lambda_return_check.d
+++ b/src/dscanner/analysis/lambda_return_check.d
@@ -16,9 +16,9 @@ final class LambdaReturnCheck : BaseAnalyzer
 
 	mixin AnalyzerInfo!"lambda_return_check";
 
-	this(string fileName, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, null, skipTests);
+		super(args);
 	}
 
 	override void visit(const FunctionLiteralExpression fLit)

--- a/src/dscanner/analysis/length_subtraction.d
+++ b/src/dscanner/analysis/length_subtraction.d
@@ -22,9 +22,9 @@ final class LengthSubtractionCheck : BaseAnalyzer
 
 	mixin AnalyzerInfo!"length_subtraction_check";
 
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const AddExpression addExpression)

--- a/src/dscanner/analysis/line_length.d
+++ b/src/dscanner/analysis/line_length.d
@@ -20,10 +20,9 @@ final class LineLengthCheck : BaseAnalyzer
 	mixin AnalyzerInfo!"long_line_check";
 
 	///
-	this(string fileName, const(Token)[] tokens, int maxLineLength, bool skipTests = false)
+	this(BaseAnalyzerArguments args, int maxLineLength)
 	{
-		super(fileName, null, skipTests);
-		this.tokens = tokens;
+		super(args);
 		this.maxLineLength = maxLineLength;
 	}
 
@@ -94,9 +93,9 @@ private:
 
 	unittest
 	{
-		assert(new LineLengthCheck(null, null, 120).checkMultiLineToken(Token(tok!"stringLiteral", "		", 0, 0, 0)) == 8);
-		assert(new LineLengthCheck(null, null, 120).checkMultiLineToken(Token(tok!"stringLiteral", "		\na", 0, 0, 0)) == 2);
-		assert(new LineLengthCheck(null, null, 120).checkMultiLineToken(Token(tok!"stringLiteral", "		\n	", 0, 0, 0)) == 5);
+		assert(new LineLengthCheck(BaseAnalyzerArguments.init, 120).checkMultiLineToken(Token(tok!"stringLiteral", "		", 0, 0, 0)) == 8);
+		assert(new LineLengthCheck(BaseAnalyzerArguments.init, 120).checkMultiLineToken(Token(tok!"stringLiteral", "		\na", 0, 0, 0)) == 2);
+		assert(new LineLengthCheck(BaseAnalyzerArguments.init, 120).checkMultiLineToken(Token(tok!"stringLiteral", "		\n	", 0, 0, 0)) == 5);
 	}
 
 	static size_t tokenByteLength()(auto ref const Token tok)
@@ -165,7 +164,6 @@ private:
 
 	enum string KEY = "dscanner.style.long_line";
 	const int maxLineLength;
-	const(Token)[] tokens;
 }
 
 @system unittest

--- a/src/dscanner/analysis/local_imports.d
+++ b/src/dscanner/analysis/local_imports.d
@@ -25,9 +25,9 @@ final class LocalImportCheck : BaseAnalyzer
 	/**
 	 * Construct with the given file name.
 	 */
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	mixin visitThing!StructBody;

--- a/src/dscanner/analysis/logic_precedence.d
+++ b/src/dscanner/analysis/logic_precedence.d
@@ -26,9 +26,9 @@ final class LogicPrecedenceCheck : BaseAnalyzer
 	enum string KEY = "dscanner.confusing.logical_precedence";
 	mixin AnalyzerInfo!"logical_precedence_check";
 
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const OrOrExpression orOr)

--- a/src/dscanner/analysis/mismatched_args.d
+++ b/src/dscanner/analysis/mismatched_args.d
@@ -14,9 +14,9 @@ final class MismatchedArgumentCheck : BaseAnalyzer
 	mixin AnalyzerInfo!"mismatched_args_check";
 
 	///
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const FunctionCallExpression fce)

--- a/src/dscanner/analysis/numbers.d
+++ b/src/dscanner/analysis/numbers.d
@@ -26,9 +26,9 @@ public:
 	/**
 	 * Constructs the style checker with the given file name.
 	 */
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const Token t)

--- a/src/dscanner/analysis/objectconst.d
+++ b/src/dscanner/analysis/objectconst.d
@@ -24,9 +24,9 @@ final class ObjectConstCheck : BaseAnalyzer
 	mixin AnalyzerInfo!"object_const_check";
 
 	///
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	mixin visitTemplate!ClassDeclaration;

--- a/src/dscanner/analysis/opequals_without_tohash.d
+++ b/src/dscanner/analysis/opequals_without_tohash.d
@@ -23,9 +23,9 @@ final class OpEqualsWithoutToHashCheck : BaseAnalyzer
 
 	mixin AnalyzerInfo!"opequals_tohash_check";
 
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const ClassDeclaration node)

--- a/src/dscanner/analysis/pokemon.d
+++ b/src/dscanner/analysis/pokemon.d
@@ -31,9 +31,9 @@ final class PokemonExceptionCheck : BaseAnalyzer
 
 	alias visit = BaseAnalyzer.visit;
 
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const LastCatch lc)

--- a/src/dscanner/analysis/properly_documented_public_functions.d
+++ b/src/dscanner/analysis/properly_documented_public_functions.d
@@ -41,9 +41,9 @@ final class ProperlyDocumentedPublicFunctions : BaseAnalyzer
 	mixin AnalyzerInfo!"properly_documented_public_functions";
 
 	///
-	this(string fileName, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, null, skipTests);
+		super(args);
 	}
 
 	override void visit(const Module mod)

--- a/src/dscanner/analysis/range.d
+++ b/src/dscanner/analysis/range.d
@@ -29,9 +29,9 @@ final class BackwardsRangeCheck : BaseAnalyzer
 	 * Params:
 	 *     fileName = the name of the file being analyzed
 	 */
-	this(string fileName, const Scope* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const ForeachStatement foreachStatement)

--- a/src/dscanner/analysis/redundant_attributes.d
+++ b/src/dscanner/analysis/redundant_attributes.d
@@ -21,9 +21,9 @@ final class RedundantAttributesCheck : ScopedBaseAnalyzer
 {
 	mixin AnalyzerInfo!"redundant_attributes_check";
 
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 		stack.length = 0;
 	}
 

--- a/src/dscanner/analysis/redundant_parens.d
+++ b/src/dscanner/analysis/redundant_parens.d
@@ -20,9 +20,9 @@ final class RedundantParenCheck : BaseAnalyzer
 	mixin AnalyzerInfo!"redundant_parens_check";
 
 	///
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const IfStatement statement)

--- a/src/dscanner/analysis/redundant_storage_class.d
+++ b/src/dscanner/analysis/redundant_storage_class.d
@@ -22,9 +22,9 @@ final class RedundantStorageClassCheck : BaseAnalyzer
 	enum string REDUNDANT_VARIABLE_ATTRIBUTES = "Variable declaration for `%s` has redundant attributes (%-(`%s`%|, %)).";
 	mixin AnalyzerInfo!"redundant_storage_classes";
 
-	this(string fileName, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, null, skipTests);
+		super(args);
 	}
 
 	override void visit(const Declaration node)

--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -307,7 +307,7 @@ void generateReport(string[] fileNames, const StaticAnalysisConfig config,
 	};
 
 	first = true;
-	StatsCollector stats = new StatsCollector("");
+	StatsCollector stats = new StatsCollector(BaseAnalyzerArguments.init);
 	ulong lineOfCodeCount;
 	foreach (fileName; fileNames)
 	{
@@ -749,220 +749,226 @@ private BaseAnalyzer[] getAnalyzersForModuleAndConfig(string fileName,
 		  m.moduleDeclaration.moduleName.identifiers !is null)
 		moduleName = m.moduleDeclaration.moduleName.identifiers.map!(e => e.text).join(".");
 
+	BaseAnalyzerArguments args = BaseAnalyzerArguments(
+		fileName: fileName,
+		tokens: tokens,
+		sc: moduleScope
+	);
+
 	if (moduleName.shouldRun!AsmStyleCheck(analysisConfig))
-		checks ~= new AsmStyleCheck(fileName, moduleScope,
-		analysisConfig.asm_style_check == Check.skipTests && !ut);
+		checks ~= new AsmStyleCheck(args.setSkipTests(
+		analysisConfig.asm_style_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!BackwardsRangeCheck(analysisConfig))
-		checks ~= new BackwardsRangeCheck(fileName, moduleScope,
-		analysisConfig.backwards_range_check == Check.skipTests && !ut);
+		checks ~= new BackwardsRangeCheck(args.setSkipTests(
+		analysisConfig.backwards_range_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!BuiltinPropertyNameCheck(analysisConfig))
-		checks ~= new BuiltinPropertyNameCheck(fileName, moduleScope,
-		analysisConfig.builtin_property_names_check == Check.skipTests && !ut);
+		checks ~= new BuiltinPropertyNameCheck(args.setSkipTests(
+		analysisConfig.builtin_property_names_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!CommaExpressionCheck(analysisConfig))
-		checks ~= new CommaExpressionCheck(fileName, moduleScope,
-		analysisConfig.comma_expression_check == Check.skipTests && !ut);
+		checks ~= new CommaExpressionCheck(args.setSkipTests(
+		analysisConfig.comma_expression_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!ConstructorCheck(analysisConfig))
-		checks ~= new ConstructorCheck(fileName, moduleScope,
-		analysisConfig.constructor_check == Check.skipTests && !ut);
+		checks ~= new ConstructorCheck(args.setSkipTests(
+		analysisConfig.constructor_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!UnmodifiedFinder(analysisConfig))
-		checks ~= new UnmodifiedFinder(fileName, moduleScope,
-		analysisConfig.could_be_immutable_check == Check.skipTests && !ut);
+		checks ~= new UnmodifiedFinder(args.setSkipTests(
+		analysisConfig.could_be_immutable_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!DeleteCheck(analysisConfig))
-		checks ~= new DeleteCheck(fileName, moduleScope,
-		analysisConfig.delete_check == Check.skipTests && !ut);
+		checks ~= new DeleteCheck(args.setSkipTests(
+		analysisConfig.delete_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!DuplicateAttributeCheck(analysisConfig))
-		checks ~= new DuplicateAttributeCheck(fileName, moduleScope,
-		analysisConfig.duplicate_attribute == Check.skipTests && !ut);
+		checks ~= new DuplicateAttributeCheck(args.setSkipTests(
+		analysisConfig.duplicate_attribute == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!EnumArrayLiteralCheck(analysisConfig))
-		checks ~= new EnumArrayLiteralCheck(fileName, moduleScope,
-		analysisConfig.enum_array_literal_check == Check.skipTests && !ut);
+		checks ~= new EnumArrayLiteralCheck(args.setSkipTests(
+		analysisConfig.enum_array_literal_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!PokemonExceptionCheck(analysisConfig))
-		checks ~= new PokemonExceptionCheck(fileName, moduleScope,
-		analysisConfig.exception_check == Check.skipTests && !ut);
+		checks ~= new PokemonExceptionCheck(args.setSkipTests(
+		analysisConfig.exception_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!FloatOperatorCheck(analysisConfig))
-		checks ~= new FloatOperatorCheck(fileName, moduleScope,
-		analysisConfig.float_operator_check == Check.skipTests && !ut);
+		checks ~= new FloatOperatorCheck(args.setSkipTests(
+		analysisConfig.float_operator_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!FunctionAttributeCheck(analysisConfig))
-		checks ~= new FunctionAttributeCheck(fileName, moduleScope,
-		analysisConfig.function_attribute_check == Check.skipTests && !ut);
+		checks ~= new FunctionAttributeCheck(args.setSkipTests(
+		analysisConfig.function_attribute_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!IfElseSameCheck(analysisConfig))
-		checks ~= new IfElseSameCheck(fileName, moduleScope,
-		analysisConfig.if_else_same_check == Check.skipTests&& !ut);
+		checks ~= new IfElseSameCheck(args.setSkipTests(
+		analysisConfig.if_else_same_check == Check.skipTests&& !ut));
 
 	if (moduleName.shouldRun!LabelVarNameCheck(analysisConfig))
-		checks ~= new LabelVarNameCheck(fileName, moduleScope,
-		analysisConfig.label_var_same_name_check == Check.skipTests && !ut);
+		checks ~= new LabelVarNameCheck(args.setSkipTests(
+		analysisConfig.label_var_same_name_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!LengthSubtractionCheck(analysisConfig))
-		checks ~= new LengthSubtractionCheck(fileName, moduleScope,
-		analysisConfig.length_subtraction_check == Check.skipTests && !ut);
+		checks ~= new LengthSubtractionCheck(args.setSkipTests(
+		analysisConfig.length_subtraction_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!LocalImportCheck(analysisConfig))
-		checks ~= new LocalImportCheck(fileName, moduleScope,
-		analysisConfig.local_import_check == Check.skipTests && !ut);
+		checks ~= new LocalImportCheck(args.setSkipTests(
+		analysisConfig.local_import_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!LogicPrecedenceCheck(analysisConfig))
-		checks ~= new LogicPrecedenceCheck(fileName, moduleScope,
-		analysisConfig.logical_precedence_check == Check.skipTests && !ut);
+		checks ~= new LogicPrecedenceCheck(args.setSkipTests(
+		analysisConfig.logical_precedence_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!MismatchedArgumentCheck(analysisConfig))
-		checks ~= new MismatchedArgumentCheck(fileName, moduleScope,
-		analysisConfig.mismatched_args_check == Check.skipTests && !ut);
+		checks ~= new MismatchedArgumentCheck(args.setSkipTests(
+		analysisConfig.mismatched_args_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!NumberStyleCheck(analysisConfig))
-		checks ~= new NumberStyleCheck(fileName, moduleScope,
-		analysisConfig.number_style_check == Check.skipTests && !ut);
+		checks ~= new NumberStyleCheck(args.setSkipTests(
+		analysisConfig.number_style_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!ObjectConstCheck(analysisConfig))
-		checks ~= new ObjectConstCheck(fileName, moduleScope,
-		analysisConfig.object_const_check == Check.skipTests && !ut);
+		checks ~= new ObjectConstCheck(args.setSkipTests(
+		analysisConfig.object_const_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!OpEqualsWithoutToHashCheck(analysisConfig))
-		checks ~= new OpEqualsWithoutToHashCheck(fileName, moduleScope,
-		analysisConfig.opequals_tohash_check == Check.skipTests && !ut);
+		checks ~= new OpEqualsWithoutToHashCheck(args.setSkipTests(
+		analysisConfig.opequals_tohash_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!RedundantParenCheck(analysisConfig))
-		checks ~= new RedundantParenCheck(fileName, moduleScope,
-		analysisConfig.redundant_parens_check == Check.skipTests && !ut);
+		checks ~= new RedundantParenCheck(args.setSkipTests(
+		analysisConfig.redundant_parens_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!StyleChecker(analysisConfig))
-		checks ~= new StyleChecker(fileName, moduleScope,
-		analysisConfig.style_check == Check.skipTests && !ut);
+		checks ~= new StyleChecker(args.setSkipTests(
+		analysisConfig.style_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!UndocumentedDeclarationCheck(analysisConfig))
-		checks ~= new UndocumentedDeclarationCheck(fileName, moduleScope,
-		analysisConfig.undocumented_declaration_check == Check.skipTests && !ut);
+		checks ~= new UndocumentedDeclarationCheck(args.setSkipTests(
+		analysisConfig.undocumented_declaration_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!UnusedLabelCheck(analysisConfig))
-		checks ~= new UnusedLabelCheck(fileName, moduleScope,
-		analysisConfig.unused_label_check == Check.skipTests && !ut);
+		checks ~= new UnusedLabelCheck(args.setSkipTests(
+		analysisConfig.unused_label_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!UnusedVariableCheck(analysisConfig))
-		checks ~= new UnusedVariableCheck(fileName, moduleScope,
-		analysisConfig.unused_variable_check == Check.skipTests && !ut);
+		checks ~= new UnusedVariableCheck(args.setSkipTests(
+		analysisConfig.unused_variable_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!UnusedParameterCheck(analysisConfig))
-		checks ~= new UnusedParameterCheck(fileName, moduleScope,
-		analysisConfig.unused_parameter_check == Check.skipTests && !ut);
+		checks ~= new UnusedParameterCheck(args.setSkipTests(
+		analysisConfig.unused_parameter_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!LineLengthCheck(analysisConfig))
-		checks ~= new LineLengthCheck(fileName, tokens,
-		analysisConfig.max_line_length,
-		analysisConfig.long_line_check == Check.skipTests && !ut);
+		checks ~= new LineLengthCheck(args.setSkipTests(
+		analysisConfig.long_line_check == Check.skipTests && !ut),
+		analysisConfig.max_line_length);
 
 	if (moduleName.shouldRun!AutoRefAssignmentCheck(analysisConfig))
-		checks ~= new AutoRefAssignmentCheck(fileName,
-		analysisConfig.auto_ref_assignment_check == Check.skipTests && !ut);
+		checks ~= new AutoRefAssignmentCheck(args.setSkipTests(
+		analysisConfig.auto_ref_assignment_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!IncorrectInfiniteRangeCheck(analysisConfig))
-		checks ~= new IncorrectInfiniteRangeCheck(fileName,
-		analysisConfig.incorrect_infinite_range_check == Check.skipTests && !ut);
+		checks ~= new IncorrectInfiniteRangeCheck(args.setSkipTests(
+		analysisConfig.incorrect_infinite_range_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!UselessAssertCheck(analysisConfig))
-		checks ~= new UselessAssertCheck(fileName,
-		analysisConfig.useless_assert_check == Check.skipTests && !ut);
+		checks ~= new UselessAssertCheck(args.setSkipTests(
+		analysisConfig.useless_assert_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!AliasSyntaxCheck(analysisConfig))
-		checks ~= new AliasSyntaxCheck(fileName,
-		analysisConfig.alias_syntax_check == Check.skipTests && !ut);
+		checks ~= new AliasSyntaxCheck(args.setSkipTests(
+		analysisConfig.alias_syntax_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!StaticIfElse(analysisConfig))
-		checks ~= new StaticIfElse(fileName,
-		analysisConfig.static_if_else_check == Check.skipTests && !ut);
+		checks ~= new StaticIfElse(args.setSkipTests(
+		analysisConfig.static_if_else_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!LambdaReturnCheck(analysisConfig))
-		checks ~= new LambdaReturnCheck(fileName,
-		analysisConfig.lambda_return_check == Check.skipTests && !ut);
+		checks ~= new LambdaReturnCheck(args.setSkipTests(
+		analysisConfig.lambda_return_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!AutoFunctionChecker(analysisConfig))
-		checks ~= new AutoFunctionChecker(fileName,
-		analysisConfig.auto_function_check == Check.skipTests && !ut);
+		checks ~= new AutoFunctionChecker(args.setSkipTests(
+		analysisConfig.auto_function_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!ImportSortednessCheck(analysisConfig))
-		checks ~= new ImportSortednessCheck(fileName,
-		analysisConfig.imports_sortedness == Check.skipTests && !ut);
+		checks ~= new ImportSortednessCheck(args.setSkipTests(
+		analysisConfig.imports_sortedness == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!ExplicitlyAnnotatedUnittestCheck(analysisConfig))
-		checks ~= new ExplicitlyAnnotatedUnittestCheck(fileName,
-		analysisConfig.explicitly_annotated_unittests == Check.skipTests && !ut);
+		checks ~= new ExplicitlyAnnotatedUnittestCheck(args.setSkipTests(
+		analysisConfig.explicitly_annotated_unittests == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!ProperlyDocumentedPublicFunctions(analysisConfig))
-		checks ~= new ProperlyDocumentedPublicFunctions(fileName,
-		analysisConfig.properly_documented_public_functions == Check.skipTests && !ut);
+		checks ~= new ProperlyDocumentedPublicFunctions(args.setSkipTests(
+		analysisConfig.properly_documented_public_functions == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!FinalAttributeChecker(analysisConfig))
-		checks ~= new FinalAttributeChecker(fileName,
-		analysisConfig.final_attribute_check == Check.skipTests && !ut);
+		checks ~= new FinalAttributeChecker(args.setSkipTests(
+		analysisConfig.final_attribute_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!VcallCtorChecker(analysisConfig))
-		checks ~= new VcallCtorChecker(fileName,
-		analysisConfig.vcall_in_ctor == Check.skipTests && !ut);
+		checks ~= new VcallCtorChecker(args.setSkipTests(
+		analysisConfig.vcall_in_ctor == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!UselessInitializerChecker(analysisConfig))
-		checks ~= new UselessInitializerChecker(fileName,
-		analysisConfig.useless_initializer == Check.skipTests && !ut);
+		checks ~= new UselessInitializerChecker(args.setSkipTests(
+		analysisConfig.useless_initializer == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!AllManCheck(analysisConfig))
-		checks ~= new AllManCheck(fileName, tokens,
-		analysisConfig.allman_braces_check == Check.skipTests && !ut);
+		checks ~= new AllManCheck(args.setSkipTests(
+		analysisConfig.allman_braces_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!AlwaysCurlyCheck(analysisConfig))
-		checks ~= new AlwaysCurlyCheck(fileName, tokens,
-		analysisConfig.always_curly_check == Check.skipTests && !ut);
+		checks ~= new AlwaysCurlyCheck(args.setSkipTests(
+		analysisConfig.always_curly_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!RedundantAttributesCheck(analysisConfig))
-		checks ~= new RedundantAttributesCheck(fileName, moduleScope,
-		analysisConfig.redundant_attributes_check == Check.skipTests && !ut);
+		checks ~= new RedundantAttributesCheck(args.setSkipTests(
+		analysisConfig.redundant_attributes_check == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!HasPublicExampleCheck(analysisConfig))
-		checks ~= new HasPublicExampleCheck(fileName, moduleScope,
-		analysisConfig.has_public_example == Check.skipTests && !ut);
+		checks ~= new HasPublicExampleCheck(args.setSkipTests(
+		analysisConfig.has_public_example == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!AssertWithoutMessageCheck(analysisConfig))
-		checks ~= new AssertWithoutMessageCheck(fileName, moduleScope,
-		analysisConfig.assert_without_msg == Check.skipTests && !ut);
+		checks ~= new AssertWithoutMessageCheck(args.setSkipTests(
+		analysisConfig.assert_without_msg == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!IfConstraintsIndentCheck(analysisConfig))
-		checks ~= new IfConstraintsIndentCheck(fileName, tokens,
-		analysisConfig.if_constraints_indent == Check.skipTests && !ut);
+		checks ~= new IfConstraintsIndentCheck(args.setSkipTests(
+		analysisConfig.if_constraints_indent == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!TrustTooMuchCheck(analysisConfig))
-		checks ~= new TrustTooMuchCheck(fileName,
-		analysisConfig.trust_too_much == Check.skipTests && !ut);
+		checks ~= new TrustTooMuchCheck(args.setSkipTests(
+		analysisConfig.trust_too_much == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!RedundantStorageClassCheck(analysisConfig))
-		checks ~= new RedundantStorageClassCheck(fileName,
-		analysisConfig.redundant_storage_classes == Check.skipTests && !ut);
+		checks ~= new RedundantStorageClassCheck(args.setSkipTests(
+		analysisConfig.redundant_storage_classes == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!UnusedResultChecker(analysisConfig))
-		checks ~= new UnusedResultChecker(fileName, moduleScope,
-		analysisConfig.unused_result == Check.skipTests && !ut);
+		checks ~= new UnusedResultChecker(args.setSkipTests(
+		analysisConfig.unused_result == Check.skipTests && !ut));
 
 	if (moduleName.shouldRun!CyclomaticComplexityCheck(analysisConfig))
-		checks ~= new CyclomaticComplexityCheck(fileName, moduleScope,
-		analysisConfig.cyclomatic_complexity == Check.skipTests && !ut,
+		checks ~= new CyclomaticComplexityCheck(args.setSkipTests(
+		analysisConfig.cyclomatic_complexity == Check.skipTests && !ut),
 		analysisConfig.max_cyclomatic_complexity.to!int);
 
 	if (moduleName.shouldRun!BodyOnDisabledFuncsCheck(analysisConfig))
-		checks ~= new BodyOnDisabledFuncsCheck(fileName, moduleScope,
-		analysisConfig.body_on_disabled_func_check == Check.skipTests && !ut);
+		checks ~= new BodyOnDisabledFuncsCheck(args.setSkipTests(
+		analysisConfig.body_on_disabled_func_check == Check.skipTests && !ut));
 
 	version (none)
 		if (moduleName.shouldRun!IfStatementCheck(analysisConfig))
-			checks ~= new IfStatementCheck(fileName, moduleScope,
-			analysisConfig.redundant_if_check == Check.skipTests && !ut);
+			checks ~= new IfStatementCheck(args.setSkipTests(
+			analysisConfig.redundant_if_check == Check.skipTests && !ut));
 
 	return checks;
 }

--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -750,9 +750,9 @@ private BaseAnalyzer[] getAnalyzersForModuleAndConfig(string fileName,
 		moduleName = m.moduleDeclaration.moduleName.identifiers.map!(e => e.text).join(".");
 
 	BaseAnalyzerArguments args = BaseAnalyzerArguments(
-		fileName: fileName,
-		tokens: tokens,
-		sc: moduleScope
+		fileName,
+		tokens,
+		moduleScope
 	);
 
 	if (moduleName.shouldRun!AsmStyleCheck(analysisConfig))

--- a/src/dscanner/analysis/static_if_else.d
+++ b/src/dscanner/analysis/static_if_else.d
@@ -19,7 +19,7 @@ import dscanner.utils : safeAccess;
  * } else if (bar) {
  * }
  * ---
- * 
+ *
  * However, it's more likely that this is a mistake.
  */
 final class StaticIfElse : BaseAnalyzer
@@ -28,9 +28,9 @@ final class StaticIfElse : BaseAnalyzer
 
 	mixin AnalyzerInfo!"static_if_else_check";
 
-	this(string fileName, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, null, skipTests);
+		super(args);
 	}
 
 	override void visit(const ConditionalStatement cc)

--- a/src/dscanner/analysis/stats_collector.d
+++ b/src/dscanner/analysis/stats_collector.d
@@ -13,9 +13,10 @@ final class StatsCollector : BaseAnalyzer
 {
 	alias visit = ASTVisitor.visit;
 
-	this(string fileName)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, null);
+		args.skipTests = false; // old behavior compatibility
+		super(args);
 	}
 
 	override void visit(const Statement statement)

--- a/src/dscanner/analysis/style.d
+++ b/src/dscanner/analysis/style.d
@@ -27,9 +27,9 @@ final class StyleChecker : BaseAnalyzer
 	enum string KEY = "dscanner.style.phobos_naming_convention";
 	mixin AnalyzerInfo!"style_check";
 
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const ModuleDeclaration dec)

--- a/src/dscanner/analysis/trust_too_much.d
+++ b/src/dscanner/analysis/trust_too_much.d
@@ -31,9 +31,9 @@ public:
 	mixin AnalyzerInfo!"trust_too_much";
 
 	///
-	this(string fileName, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const AtAttribute d)

--- a/src/dscanner/analysis/undocumented.d
+++ b/src/dscanner/analysis/undocumented.d
@@ -23,9 +23,9 @@ final class UndocumentedDeclarationCheck : BaseAnalyzer
 
 	mixin AnalyzerInfo!"undocumented_declaration_check";
 
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const Module mod)

--- a/src/dscanner/analysis/unmodified.d
+++ b/src/dscanner/analysis/unmodified.d
@@ -21,9 +21,9 @@ final class UnmodifiedFinder : BaseAnalyzer
 	mixin AnalyzerInfo!"could_be_immutable_check";
 
 	///
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const Module mod)

--- a/src/dscanner/analysis/unused.d
+++ b/src/dscanner/analysis/unused.d
@@ -20,12 +20,10 @@ abstract class UnusedIdentifierCheck : BaseAnalyzer
 	alias visit = BaseAnalyzer.visit;
 
 	/**
-	 * Params:
-	 *     fileName = the name of the file being analyzed
 	 */
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 		re = regex("[\\p{Alphabetic}_][\\w_]*");
 	}
 
@@ -421,15 +419,13 @@ abstract class UnusedStorageCheck : UnusedIdentifierCheck
 
 	/**
 	 * Params:
-	 *      fileName	= the name of the file being analyzed
-	 *		sc			= the scope
-	 *		skipTest	= whether tests should be analyzed
-	 *		publicType	= declaration kind used in error messages, e.g. "Variable"s
-	 *		reportType	= declaration kind used in error reports, e.g. "unused_variable"
+	 *     args       = commonly shared analyzer arguments
+	 *     publicType = declaration kind used in error messages, e.g. "Variable"s
+	 *     reportType = declaration kind used in error reports, e.g. "unused_variable"
 	 */
-	this(string fileName, const(Scope)* sc, bool skipTests = false, string publicType = null, string reportType = null)
+	this(BaseAnalyzerArguments args, string publicType = null, string reportType = null)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 		this.publicType = publicType;
 		this.reportType = reportType;
 	}

--- a/src/dscanner/analysis/unused_label.d
+++ b/src/dscanner/analysis/unused_label.d
@@ -21,9 +21,9 @@ final class UnusedLabelCheck : BaseAnalyzer
 	mixin AnalyzerInfo!"unused_label_check";
 
 	///
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests);
+		super(args);
 	}
 
 	override void visit(const Module mod)

--- a/src/dscanner/analysis/unused_parameter.d
+++ b/src/dscanner/analysis/unused_parameter.d
@@ -23,9 +23,9 @@ final class UnusedParameterCheck : UnusedStorageCheck
 	 * Params:
 	 *     fileName = the name of the file being analyzed
 	 */
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests, "Parameter", "unused_parameter");
+		super(args, "Parameter", "unused_parameter");
 	}
 
 	override void visit(const Parameter parameter)

--- a/src/dscanner/analysis/unused_result.d
+++ b/src/dscanner/analysis/unused_result.d
@@ -41,9 +41,9 @@ public:
     const(DSymbol)* noreturn_;
 
     ///
-    this(string fileName, const(Scope)* sc, bool skipTests = false)
+    this(BaseAnalyzerArguments args)
     {
-        super(fileName, sc, skipTests);
+        super(args);
         void_ = sc.getSymbolsByName(internString("void"))[0];
         auto symbols = sc.getSymbolsByName(internString("noreturn"));
         if (symbols.length > 0)

--- a/src/dscanner/analysis/unused_variable.d
+++ b/src/dscanner/analysis/unused_variable.d
@@ -23,9 +23,9 @@ final class UnusedVariableCheck : UnusedStorageCheck
 	 * Params:
 	 *     fileName = the name of the file being analyzed
 	 */
-	this(string fileName, const(Scope)* sc, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, sc, skipTests, "Variable", "unused_variable");
+		super(args, "Variable", "unused_variable");
 	}
 
 	override void visit(const VariableDeclaration variableDeclaration)

--- a/src/dscanner/analysis/useless_assert.d
+++ b/src/dscanner/analysis/useless_assert.d
@@ -30,9 +30,9 @@ final class UselessAssertCheck : BaseAnalyzer
 	mixin AnalyzerInfo!"useless_assert_check";
 
 	///
-	this(string fileName, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, null, skipTests);
+		super(args);
 	}
 
 	override void visit(const AssertExpression ae)

--- a/src/dscanner/analysis/useless_initializer.d
+++ b/src/dscanner/analysis/useless_initializer.d
@@ -56,9 +56,9 @@ private:
 public:
 
 	///
-	this(string fileName, bool skipTests = false)
+	this(BaseAnalyzerArguments args)
 	{
-		super(fileName, null, skipTests);
+		super(args);
 		_inStruct.insert(false);
 	}
 

--- a/src/dscanner/analysis/vcall_in_ctor.d
+++ b/src/dscanner/analysis/vcall_in_ctor.d
@@ -145,9 +145,9 @@ private:
 public:
 
     ///
-    this(string fileName, bool skipTests = false)
+    this(BaseAnalyzerArguments args)
     {
-        super(fileName, null, skipTests);
+        super(args);
     }
 
     override void visit(const(ClassDeclaration) decl)


### PR DESCRIPTION
also immediately makes tokens a part of it

This struct can for example precompute token indices for line endings.

I think this cleans up a little code debt and also allows automatic construction for most analyzers (not done in this PR) and with that also a cleaner way of introspecting configuration in the future for the INI config and passing it in through the constructor automatically.

The tokens array is available in each analyzer now, allowing to implement helper methods that operate with those, such as the diagnostic helpers.