### PR TITLE
Fix build on BSD

### DIFF
--- a/makefile
+++ b/makefile
@@ -86,8 +86,6 @@ else ifneq (,$(findstring gdc, $(DC)))
 	WRITE_TO_TARGET_NAME = -o $@
 endif
 
-SHELL:=/usr/bin/env bash
-
 GITHASH = bin/githash.txt
 
 

--- a/src/dscanner/main.d
+++ b/src/dscanner/main.d
@@ -574,6 +574,9 @@ private enum CONFIG_FILE_NAME = "dscanner.ini";
 version (linux) version = useXDG;
 version (BSD) version = useXDG;
 version (FreeBSD) version = useXDG;
+version (OpenBSD) version = useXDG;
+version (NetBSD) version = useXDG;
+version (DragonflyBSD) version = useXDG;
 version (OSX) version = useXDG;
 
 /**


### PR DESCRIPTION
Removed the line `SHELL:=/usr/bin/env bash`. Most BSDs don't ship bash in the base system by default and the build doesn't need it anyway.

Also added some more version statements to define useXDG for the other BSDs (`version(BSD)` only applies for BSDs without version identifiers)