### PR TITLE
[style.alias_syntax] Add `AutoFix` replacement

### DIFF
--- a/src/dscanner/analysis/alias_syntax_check.d
+++ b/src/dscanner/analysis/alias_syntax_check.d
@@ -25,13 +25,64 @@ final class AliasSyntaxCheck : BaseAnalyzer
 
 	override void visit(const AliasDeclaration ad)
 	{
+		// new alias syntax uses `ad.initializers` instead
 		if (ad.declaratorIdentifierList is null)
 			return;
 		assert(ad.declaratorIdentifierList.identifiers.length > 0,
 				"Identifier list length is zero, libdparse has a bug");
+
+		static string tokenStr(const Token[] tokens)
+		{
+			string r;
+			foreach (i, t; tokens)
+			{
+				if (i)
+				{
+					// keep whitespace to separate multiple tokens like original
+					foreach (tt; tokens[i - 1].trailingTrivia)
+						r ~= tt.text;
+				}
+				foreach (lt; t.leadingTrivia)
+					r ~= lt.text;
+
+				string st = t.text ? t.text : t.type.str;
+				assert(st.length);
+				r ~= st;
+			}
+			return r;
+		}
+		// `alias storage target ident, ident2;`
+		string target;
+		foreach (i, sc; ad.storageClasses)
+		{
+			target ~= tokenStr(sc.tokens);
+			target ~= ' ';
+		}
+		target ~= tokenStr(ad.type.tokens);
+		// or single function type:
+		// `alias storage type ident(params) attributes;`
+		if (ad.parameters)
+		{
+			target ~= tokenStr(ad.parameters.tokens);
+			foreach (fa; ad.memberFunctionAttributes)
+			{
+				target ~= ' ';
+				target ~= tokenStr(fa.tokens);
+			}
+		}
+		// need `ident = target, ident2 = target`
+		string rep;
+		foreach (i, t; ad.declaratorIdentifierList.identifiers)
+		{
+			if (i)
+				rep ~= ", ";
+			rep ~= t.text ~ " = " ~ target;
+		}
 		addErrorMessage(ad, KEY,
 				"Prefer the new \"'alias' identifier '=' type ';'\" syntax"
-				~ " to the  old \"'alias' type identifier ';'\" syntax.");
+				~ " to the old \"'alias' type identifier ';'\" syntax.",
+				[AutoFix.replacement(ad.tokens[1 .. $ - 1], rep,
+					"Rewrite alias to use assignment syntax")]);
 	}
 
 private:
@@ -40,7 +91,7 @@ private:
 
 unittest
 {
-	import dscanner.analysis.helpers : assertAnalyzerWarnings;
+	import dscanner.analysis.helpers : assertAnalyzerWarnings, assertAutoFix;
 	import dscanner.analysis.config : StaticAnalysisConfig, Check, disabledConfig;
 	import std.stdio : stderr;
 
@@ -48,8 +99,29 @@ unittest
 	sac.alias_syntax_check = Check.enabled;
 	assertAnalyzerWarnings(q{
 		alias int abcde; /+
-		^^^^^^^^^^^^^^^^ [warn]: Prefer the new "'alias' identifier '=' type ';'" syntax to the  old "'alias' type identifier ';'" syntax.+/
+		^^^^^^^^^^^^^^^^ [warn]: Prefer the new "'alias' identifier '=' type ';'" syntax to the old "'alias' type identifier ';'" syntax.+/
 		alias abcde = int;
+		alias xyz[] a, b; /+
+		^^^^^^^^^^^^^^^^^ [warn]: Prefer the new "'alias' identifier '=' type ';'" syntax to the old "'alias' type identifier ';'" syntax.+/
+		alias a = xyz, b = xyz;
+		alias void Func(); /+
+		^^^^^^^^^^^^^^^^^^ [warn]: Prefer the new "'alias' identifier '=' type ';'" syntax to the old "'alias' type identifier ';'" syntax.+/
+		alias Func = void();
+		alias tem(T) = T!int;
+	}c, sac);
+
+	assertAutoFix(q{
+		alias T * PT; // fix
+		alias int[f(1, 2) + 3] sa; // fix
+		alias void Func(int i) pure @att(4 * 5.g); // fix
+		alias extern (C) void function() FP; // fix
+		alias xyz a, b; // fix
+	}c, q{
+		alias PT = T *; // fix
+		alias sa = int[f(1, 2) + 3]; // fix
+		alias Func = void(int i) pure @att(4 * 5.g); // fix
+		alias FP = extern (C) void function(); // fix
+		alias a = xyz, b = xyz; // fix
 	}c, sac);
 
 	stderr.writeln("Unittest for AliasSyntaxCheck passed.");


### PR DESCRIPTION
Using `alias target ident;` syntax will be an error in the 2024 edition: https://github.com/dlang/dmd/pull/22244. (Perhaps `legacy.alias_syntax` might be a better setting key than `style.alias_syntax`, though maybe best not to change it if tools depend on the current name.)

This should handle all cases of old [alias syntax](https://dlang.org/spec/declaration.html#alias):
```d
    alias StorageClassesopt BasicType TypeSuffixesopt Identifiers ;
    alias StorageClassesopt BasicType FuncDeclarator ;
```
There is [a PR to update `druntime/src`](https://github.com/dlang/dmd/pull/22490). Although that was made using an updated `dfix`, I've checked the diff from this dscanner change and the only differences are on 2 lines where the trailing whitespace before `;` is different. I don't think they matter much.

Also extend `assertAnalyzerWarnings` tests.

I also made a `tokenStr` function - I'm not sure if a similar equivalent exists somewhere, it seems a useful general function.

---
Enhancement: When the target is a function pointer/delegate and there are multiple identifiers, it can generate long lines even when the original line was not too long. See the `LPCCHOOKPROC` part of the description [here](https://github.com/dlang/dmd/pull/22490). That mentions either using newlines before each identifier or changing the target for the remaining identifiers to the first identifier. Either of those should be straightforward to implement. The same can happen with other complicated targets. There could be a heuristic to enable different formatting when the target string length is more than e.g. 20.